### PR TITLE
fix: consolidate SonarCloud scan to show combined API and UI coverage

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,34 +78,16 @@ jobs:
       - name: Restore API dependencies
         run: dotnet restore ccDiary.sln
 
-      - name: Install SonarScanner and dotnet-coverage
+      - name: Install dotnet-coverage and reportgenerator
         run: |
-          dotnet tool install --global dotnet-sonarscanner
           dotnet tool install --global dotnet-coverage
           dotnet tool install --global dotnet-reportgenerator-globaltool
-          
-      - name: SonarQube Begin
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          dotnet sonarscanner begin \
-            /k:"${{ vars.SONAR_PROJECT_KEY }}" \
-            /o:"${{ vars.SONAR_ORGANIZATION }}" \
-            /d:sonar.token="${{ secrets.SONAR_TOKEN }}" \
-            /d:sonar.host.url="https://sonarcloud.io" \
-            /d:sonar.cs.vscoveragexml.reportsPaths="coverage.xml"
 
       - name: Build API
         run: dotnet build ccDiary.sln --no-incremental --configuration Release --no-restore /p:Version=${{ needs.build-prep.outputs.app_version }}
 
       - name: Test API
         run: dotnet-coverage collect "dotnet test ccDiary.sln --configuration Release --no-build --verbosity normal --logger trx" -f xml -o coverage.xml
-
-      - name: SonarQube End
-        if: always()
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2.16.1
@@ -187,6 +169,42 @@ jobs:
     outputs:
       image_tag: ${{ steps.image_tag.outputs.value }}
     
+  sonar-scan:
+    needs: [build-api, build-ui]
+    runs-on: ubuntu-latest
+    environment: none
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Download API coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: api-coverage
+          path: src/api
+
+      - name: Download UI coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: ui-coverage
+          path: src/ui/coverage
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@v3
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: >
+            -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }}
+            -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
+
   deploy-api:
     environment: ${{ github.ref == 'refs/heads/main' && 'staging' || 'dev' }}
 
@@ -303,19 +321,6 @@ jobs:
 
       - name: Run UI Tests
         run: npm run test:ci
-
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v3
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          projectBaseDir: src/ui
-          args: >
-            -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }}
-            -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
-            -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
-            -Dsonar.exclusions=**/node_modules/**,**/dist/**,**/*.d.ts
 
       - name: Upload Test Result Files
         uses: actions/upload-artifact@v4

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+# Source directories (API C# + UI TypeScript/Vue)
+sonar.sources=src/api/ccDiaryApi,src/ui/src
+
+# Test directories
+sonar.tests=src/api/ccDiaryApiTest,src/ui/tests
+
+# Exclusions
+sonar.exclusions=**/Migrations/**,**/node_modules/**,**/dist/**,**/*.d.ts
+sonar.coverage.exclusions=**/Migrations/**,**/node_modules/**,**/dist/**,**/*.d.ts
+
+# Coverage reports
+sonar.cs.vscoveragexml.reportsPaths=src/api/coverage.xml
+sonar.javascript.lcov.reportPaths=src/ui/coverage/lcov.info
+sonar.typescript.lcov.reportPaths=src/ui/coverage/lcov.info


### PR DESCRIPTION
## Summary

- Fixes #50 — SonarCloud was only showing UI coverage because the UI scan (running second) overwrote the API scan
- Adds `sonar-project.properties` at the repo root referencing both source dirs and both coverage reports
- Replaces two separate SonarCloud analyses with a single `sonar-scan` job that runs after `build-api` and `build-ui`, downloads both coverage artifacts, and scans once from the repo root
- API now builds exactly once (no duplicate build)

## Test plan

- [ ] CI passes with the new `sonar-scan` job
- [ ] SonarCloud dashboard shows coverage for both API (C#) and UI (TypeScript/Vue)
- [ ] Only one analysis appears per CI run in SonarCloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)