### PR TITLE
refactor: move CI config from secrets to variables, fix SQL free-tier on prod

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -742,7 +742,7 @@ jobs:
 
     environment: none
 
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -252,17 +252,17 @@ jobs:
         run: |
           ENV_VARS=(
             "RUN_MIGRATIONS=true"
-            "OTEL_EXPORTER_OTLP_ENDPOINT=${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}"
+            "OTEL_EXPORTER_OTLP_ENDPOINT=${{ vars.OTEL_EXPORTER_OTLP_ENDPOINT }}"
             "OTEL_EXPORTER_OTLP_HEADERS=${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}"
             "OTEL_SERVICE_NAME=ccDiaryApi"
-            "Graph__TenantId=${{ secrets.TENANT_ID }}"
-            "Graph__ClientId=${{ secrets.ENTRA_CLIENT_ID }}"
+            "Graph__TenantId=${{ vars.TENANT_ID }}"
+            "Graph__ClientId=${{ vars.ENTRA_CLIENT_ID }}"
             "Graph__ClientSecret=${{ secrets.ENTRA_CLIENT_SECRET }}"
-            "Graph__InviteRedirectUrl=${{ secrets.GRAPH_INVITE_REDIRECT_URL }}"
+            "Graph__InviteRedirectUrl=${{ vars.GRAPH_INVITE_REDIRECT_URL }}"
             "Graph__AppDisplayName=Cooking Code Diary"
-            "BootstrapAdmin__ObjectId=${{ secrets.BOOTSTRAP_ADMIN_OBJECT_ID }}"
+            "BootstrapAdmin__ObjectId=${{ vars.BOOTSTRAP_ADMIN_OBJECT_ID }}"
             "BootstrapAdmin__Email=${{ secrets.BOOTSTRAP_ADMIN_EMAIL }}"
-            "BootstrapAdmin__DisplayName=${{ secrets.BOOTSTRAP_ADMIN_DISPLAY_NAME }}"
+            "BootstrapAdmin__DisplayName=${{ vars.BOOTSTRAP_ADMIN_DISPLAY_NAME }}"
           )
           # Construct the connection string from the individual server/DB name
           # variables (the same ones used by the wake-SQL step, so known-correct).
@@ -518,11 +518,11 @@ jobs:
 
       - name: "Configure UI"
         env:
-          VITE_API: ${{ secrets.API_URL }}
-          VITE_APPLICATION_ID_URI: ${{ secrets.ENTRA_APPLICATION_ID_URI }}
-          VITE_CLIENT_ID: ${{ secrets.ENTRA_CLIENT_ID }}
-          VITE_TENANT_ID: ${{ secrets.TENANT_ID }}
-          VITE_FARO_URL: ${{ secrets.GRAFANA_FARO_URL }}
+          VITE_API: ${{ vars.API_URL }}
+          VITE_APPLICATION_ID_URI: ${{ vars.ENTRA_APPLICATION_ID_URI }}
+          VITE_CLIENT_ID: ${{ vars.ENTRA_CLIENT_ID }}
+          VITE_TENANT_ID: ${{ vars.TENANT_ID }}
+          VITE_FARO_URL: ${{ vars.GRAFANA_FARO_URL }}
           VITE_ENVIRONMENT: ${{ github.ref == 'refs/heads/main' && 'staging' || 'dev' }}
         run: |
           node << 'SCRIPT'
@@ -561,10 +561,10 @@ jobs:
         if: github.event_name == 'pull_request'
         id: add-entra-redirect
         env:
-          AZURE_CLIENT_ID: ${{ secrets.ENTRA_CLIENT_ID }}
+          AZURE_CLIENT_ID: ${{ vars.ENTRA_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.ENTRA_CLIENT_SECRET }}
-          AZURE_TENANT_ID: ${{ secrets.TENANT_ID_DEV }}
-          ENTRA_APP_OBJECT_ID: ${{ secrets.ENTRA_APP_OBJECT_ID }}
+          AZURE_TENANT_ID: ${{ vars.TENANT_ID }}
+          ENTRA_APP_OBJECT_ID: ${{ vars.ENTRA_APP_OBJECT_ID }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Try common outputs from the static web apps deploy action
@@ -670,10 +670,10 @@ jobs:
       - name: Get API bearer token
         id: api_token
         env:
-          AZURE_CLIENT_ID: ${{ secrets.ENTRA_CLIENT_ID }}
+          AZURE_CLIENT_ID: ${{ vars.ENTRA_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.ENTRA_CLIENT_SECRET }}
-          AZURE_TENANT_ID: ${{ secrets.TENANT_ID }}
-          ENTRA_APPLICATION_ID_URI: ${{ secrets.ENTRA_APPLICATION_ID_URI }}
+          AZURE_TENANT_ID: ${{ vars.TENANT_ID }}
+          ENTRA_APPLICATION_ID_URI: ${{ vars.ENTRA_APPLICATION_ID_URI }}
         run: |
           RESPONSE=$(curl -s -X POST \
             -d "client_id=$AZURE_CLIENT_ID&scope=${ENTRA_APPLICATION_ID_URI}/.default&client_secret=$AZURE_CLIENT_SECRET&grant_type=client_credentials" \

--- a/.github/workflows/entra-cleanup.yml
+++ b/.github/workflows/entra-cleanup.yml
@@ -41,10 +41,10 @@ jobs:
       - name: Remove Entra SPA redirect URI
         if: steps.find-comment.outputs.preview_url != ''
         env:
-          AZURE_CLIENT_ID: ${{ secrets.ENTRA_CLIENT_ID }}
+          AZURE_CLIENT_ID: ${{ vars.ENTRA_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.ENTRA_CLIENT_SECRET }}
-          AZURE_TENANT_ID: ${{ secrets.TENANT_ID }}
-          ENTRA_APP_OBJECT_ID: ${{ secrets.ENTRA_APP_OBJECT_ID }}
+          AZURE_TENANT_ID: ${{ vars.TENANT_ID }}
+          ENTRA_APP_OBJECT_ID: ${{ vars.ENTRA_APP_OBJECT_ID }}
         run: |
           PREVIEW_URL="${{ steps.find-comment.outputs.preview_url }}"
           echo "Removing preview URL: $PREVIEW_URL"

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -35,11 +35,11 @@ jobs:
 
       - name: "Configure UI (prod)"
         env:
-          VITE_API: ${{ secrets.API_URL }}
-          VITE_APPLICATION_ID_URI: ${{ secrets.ENTRA_APPLICATION_ID_URI }}
-          VITE_CLIENT_ID: ${{ secrets.ENTRA_CLIENT_ID }}
-          VITE_TENANT_ID: ${{ secrets.TENANT_ID }}
-          VITE_FARO_URL: ${{ secrets.GRAFANA_FARO_URL }}
+          VITE_API: ${{ vars.API_URL }}
+          VITE_APPLICATION_ID_URI: ${{ vars.ENTRA_APPLICATION_ID_URI }}
+          VITE_CLIENT_ID: ${{ vars.ENTRA_CLIENT_ID }}
+          VITE_TENANT_ID: ${{ vars.TENANT_ID }}
+          VITE_FARO_URL: ${{ vars.GRAFANA_FARO_URL }}
           VITE_ENVIRONMENT: prod
         run: |
           node << 'SCRIPT'
@@ -78,17 +78,17 @@ jobs:
             --image ${{ steps.api_image.outputs.value }} \
             --set-env-vars \
               "RUN_MIGRATIONS=true" \
-              "OTEL_EXPORTER_OTLP_ENDPOINT=${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}" \
+              "OTEL_EXPORTER_OTLP_ENDPOINT=${{ vars.OTEL_EXPORTER_OTLP_ENDPOINT }}" \
               "OTEL_EXPORTER_OTLP_HEADERS=${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}" \
               "OTEL_SERVICE_NAME=ccDiaryApi" \
-              "Graph__TenantId=${{ secrets.TENANT_ID }}" \
-              "Graph__ClientId=${{ secrets.ENTRA_CLIENT_ID }}" \
+              "Graph__TenantId=${{ vars.TENANT_ID }}" \
+              "Graph__ClientId=${{ vars.ENTRA_CLIENT_ID }}" \
               "Graph__ClientSecret=${{ secrets.ENTRA_CLIENT_SECRET }}" \
-              "Graph__InviteRedirectUrl=${{ secrets.GRAPH_INVITE_REDIRECT_URL }}" \
+              "Graph__InviteRedirectUrl=${{ vars.GRAPH_INVITE_REDIRECT_URL }}" \
               "Graph__AppDisplayName=Cooking Code Diary" \
-              "BootstrapAdmin__ObjectId=${{ secrets.BOOTSTRAP_ADMIN_OBJECT_ID }}" \
+              "BootstrapAdmin__ObjectId=${{ vars.BOOTSTRAP_ADMIN_OBJECT_ID }}" \
               "BootstrapAdmin__Email=${{ secrets.BOOTSTRAP_ADMIN_EMAIL }}" \
-              "BootstrapAdmin__DisplayName=${{ secrets.BOOTSTRAP_ADMIN_DISPLAY_NAME }}" \
+              "BootstrapAdmin__DisplayName=${{ vars.BOOTSTRAP_ADMIN_DISPLAY_NAME }}" \
             --no-wait \
             --output none
 

--- a/deploy/main.bicep
+++ b/deploy/main.bicep
@@ -12,6 +12,8 @@ param adminUserSID string
 param devApiContainerImage string
 param externalDomainName string?
 param location string = deployment().location
+@allowed(['AutoPause', 'BillOverUsage'])
+param freeLimitExhaustionBehavior string = 'AutoPause'
 
 resource resourceGroup 'Microsoft.Resources/resourceGroups@2023-07-01' = {
   name: 'rg-${name}-${environment}'
@@ -29,6 +31,7 @@ module resourceGroupModule 'resourceGroup.bicep' = {
     containerImageName: devApiContainerImage
     externalDomainName: externalDomainName
     location: location
+    freeLimitExhaustionBehavior: freeLimitExhaustionBehavior
   }
 }
 

--- a/deploy/resourceGroup.bicep
+++ b/deploy/resourceGroup.bicep
@@ -7,14 +7,13 @@ param adminUserSID string
 param externalDomainName string?
 param location string = resourceGroup().location
 param containerImageName string
+// FreeLimitExhaustionBehavior is immutable once set to BillOverUsage.
+// The deployment script reads the current value before deploying and passes it here
+// so we never attempt an illegal transition.
+@allowed(['AutoPause', 'BillOverUsage'])
+param freeLimitExhaustionBehavior string = 'AutoPause'
 var appName string = '${name}-${environment}'
 var sqlServerName string = 'sql-${appName}'
-// Free-tier auto-pause is only applied to non-prod; prod's FreeLimitExhaustionBehavior
-// is immutable once set to BillOverUsage so we omit the properties entirely there.
-var freeLimitProperties = environment != 'prod' ? {
-  useFreeLimit: true
-  freeLimitExhaustionBehavior: 'AutoPause'
-} : {}
 
 resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: 'logs-${appName}'
@@ -80,7 +79,7 @@ resource sqlDatabase 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
     name: 'GP_S_Gen5_1'
     tier: 'GeneralPurpose'
   }
-  properties: union({
+  properties: {
     createMode: 'Default'
     collation: 'SQL_Latin1_General_CP1_CI_AS'
     maxSizeBytes: 34359738368 // 32 GB
@@ -92,8 +91,10 @@ resource sqlDatabase 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
     requestedBackupStorageRedundancy: 'Local'
     catalogCollation: 'SQL_Latin1_General_CP1_CI_AS'
     isLedgerOn: false
+    useFreeLimit: true
+    freeLimitExhaustionBehavior: freeLimitExhaustionBehavior
     maintenanceConfigurationId: subscriptionResourceId('Microsoft.Maintenance/publicMaintenanceConfigurations', 'SQL_WestEurope_DB_2')
-  }, freeLimitProperties)
+  }
 }
 
 resource staticSite 'Microsoft.Web/staticSites@2023-01-01' = {

--- a/deploy/resourceGroup.bicep
+++ b/deploy/resourceGroup.bicep
@@ -9,6 +9,12 @@ param location string = resourceGroup().location
 param containerImageName string
 var appName string = '${name}-${environment}'
 var sqlServerName string = 'sql-${appName}'
+// Free-tier auto-pause is only applied to non-prod; prod's FreeLimitExhaustionBehavior
+// is immutable once set to BillOverUsage so we omit the properties entirely there.
+var freeLimitProperties = environment != 'prod' ? {
+  useFreeLimit: true
+  freeLimitExhaustionBehavior: 'AutoPause'
+} : {}
 
 resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
   name: 'logs-${appName}'
@@ -74,7 +80,7 @@ resource sqlDatabase 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
     name: 'GP_S_Gen5_1'
     tier: 'GeneralPurpose'
   }
-  properties: {
+  properties: union({
     createMode: 'Default'
     collation: 'SQL_Latin1_General_CP1_CI_AS'
     maxSizeBytes: 34359738368 // 32 GB
@@ -86,10 +92,8 @@ resource sqlDatabase 'Microsoft.Sql/servers/databases@2023-08-01-preview' = {
     requestedBackupStorageRedundancy: 'Local'
     catalogCollation: 'SQL_Latin1_General_CP1_CI_AS'
     isLedgerOn: false
-    useFreeLimit: true
-    freeLimitExhaustionBehavior: 'AutoPause'
     maintenanceConfigurationId: subscriptionResourceId('Microsoft.Maintenance/publicMaintenanceConfigurations', 'SQL_WestEurope_DB_2')
-  }
+  }, freeLimitProperties)
 }
 
 resource staticSite 'Microsoft.Web/staticSites@2023-01-01' = {

--- a/scripts/buildInfrastructure.ps1
+++ b/scripts/buildInfrastructure.ps1
@@ -278,11 +278,22 @@ Write-Host "  Subscription ID: $subscriptionId" -ForegroundColor Gray
 Write-Host "Starting infrastructure deployment..." -ForegroundColor Cyan
 Write-Host "  Configuring environment: ${name}_${environment}" -ForegroundColor Gray
 
+# FreeLimitExhaustionBehavior is immutable once set to BillOverUsage.
+# Read the current value so we never attempt an illegal AutoPause -> BillOverUsage -> AutoPause transition.
+$appName = "${name}-${environment}"
+$existingFreeLimitBehavior = az sql db show `
+  --name "sqldb-${appName}" `
+  --server "sql-${appName}" `
+  --resource-group "rg-${name}-${environment}" `
+  --query "freeLimitExhaustionBehavior" -o tsv 2>$null
+$freeLimitExhaustionBehavior = if ($existingFreeLimitBehavior -eq 'BillOverUsage') { 'BillOverUsage' } else { 'AutoPause' }
+Write-Host "  SQL freeLimitExhaustionBehavior: $freeLimitExhaustionBehavior" -ForegroundColor Gray
+
 # Deploy using Azure CLI
 $deploymentResult = az deployment sub create `
   --location $location `
   --template-file "$PSScriptRoot\..\deploy\main.bicep" `
-  --parameters name=$name environment="$environment" adminUser=$userPrincipalName adminUserSID=$userId devApiContainerImage=$devApiContainerImage externalDomainName="$externalDomainName" `
+  --parameters name=$name environment="$environment" adminUser=$userPrincipalName adminUserSID=$userId devApiContainerImage=$devApiContainerImage externalDomainName="$externalDomainName" freeLimitExhaustionBehavior=$freeLimitExhaustionBehavior `
   --output json | ConvertFrom-Json
 
 # Check if deployment succeeded

--- a/scripts/buildInfrastructure.ps1
+++ b/scripts/buildInfrastructure.ps1
@@ -429,23 +429,27 @@ if ($LASTEXITCODE -eq 0) {
 $staticSiteSecrets = az staticwebapp secrets list --name "$staticSiteName" --resource-group "$resourceGroupName" --output json | ConvertFrom-Json
 $token = $staticSiteSecrets.properties.apiKey
 gh api --method PUT repos/${gitHubOwnerRepo}/environments/${environment}
-gh variable set "CONTAINER_APP_NAME".ToUpper() --body "$containerAppName" --repo $gitHubRepo --env "${environment}"
-gh variable set "RESOURCE_GROUP_NAME".ToUpper() --body "$resourceGroupName" --repo $gitHubRepo --env "${environment}"
-gh secret set "AZURE_STATIC_WEB_APPS_API_TOKEN".ToUpper() --body "$token" --repo $gitHubRepo --env "${environment}"
-gh secret set "API_URL".ToUpper() --body "https://$containerAppUrl/api/" --repo $gitHubRepo --env "${environment}"
-gh secret set "ENTRA_CLIENT_ID".ToUpper() --body "$entraClientId" --repo $gitHubRepo --env "${environment}"
-gh secret set "ENTRA_APP_OBJECT_ID".ToUpper() --body "$entraObjectId" --repo $gitHubRepo --env "${environment}"
-gh secret set "ENTRA_CLIENT_SECRET".ToUpper() --body "${entraClientCredentialsPassword}" --repo $gitHubRepo --env "${environment}"
-gh secret set "ENTRA_APPLICATION_ID_URI".ToUpper() --body "$entraApplicationIdURI" --repo $gitHubRepo --env "${environment}"
-gh secret set "TENANT_ID".ToUpper() --body "$tenantId" --repo $gitHubRepo --env "${environment}"
-gh secret set "AZURE_CREDENTIALS".ToUpper() --body "$azureCredentials" --repo $gitHubRepo --env "${environment}"
-gh secret set "OTEL_EXPORTER_OTLP_ENDPOINT" --body "$grafanaOtlpEndpoint" --repo $gitHubRepo --env "${environment}"
+# Variables — non-sensitive configuration
+gh variable set "CONTAINER_APP_NAME" --body "$containerAppName" --repo $gitHubRepo --env "${environment}"
+gh variable set "RESOURCE_GROUP_NAME" --body "$resourceGroupName" --repo $gitHubRepo --env "${environment}"
+gh variable set "SQL_DB_NAME" --body "$databaseName" --repo $gitHubRepo --env "${environment}"
+gh variable set "SQL_SERVER_NAME" --body "$databaseServerName" --repo $gitHubRepo --env "${environment}"
+gh variable set "API_URL" --body "https://$containerAppUrl/api/" --repo $gitHubRepo --env "${environment}"
+gh variable set "ENTRA_CLIENT_ID" --body "$entraClientId" --repo $gitHubRepo --env "${environment}"
+gh variable set "ENTRA_APP_OBJECT_ID" --body "$entraObjectId" --repo $gitHubRepo --env "${environment}"
+gh variable set "ENTRA_APPLICATION_ID_URI" --body "$entraApplicationIdURI" --repo $gitHubRepo --env "${environment}"
+gh variable set "TENANT_ID" --body "$tenantId" --repo $gitHubRepo --env "${environment}"
+gh variable set "OTEL_EXPORTER_OTLP_ENDPOINT" --body "$grafanaOtlpEndpoint" --repo $gitHubRepo --env "${environment}"
+gh variable set "GRAFANA_FARO_URL" --body "$grafanaFaroUrl" --repo $gitHubRepo --env "${environment}"
+# Secrets — credentials and tokens only
+gh secret set "AZURE_STATIC_WEB_APPS_API_TOKEN" --body "$token" --repo $gitHubRepo --env "${environment}"
+gh secret set "ENTRA_CLIENT_SECRET" --body "${entraClientCredentialsPassword}" --repo $gitHubRepo --env "${environment}"
+gh secret set "AZURE_CREDENTIALS" --body "$azureCredentials" --repo $gitHubRepo --env "${environment}"
 gh secret set "OTEL_EXPORTER_OTLP_HEADERS" --body "$grafanaOtlpAuthHeader" --repo $gitHubRepo --env "${environment}"
-gh secret set "GRAFANA_FARO_URL" --body "$grafanaFaroUrl" --repo $gitHubRepo --env "${environment}"
-gh secret set "GRAPH_INVITE_REDIRECT_URL" --body "https://$staticSiteUrl/" --repo $gitHubRepo --env "${environment}"
-gh secret set "BOOTSTRAP_ADMIN_OBJECT_ID" --body "$bootstrapAdminObjectId" --repo $gitHubRepo --env "${environment}"
+gh variable set "GRAPH_INVITE_REDIRECT_URL" --body "https://$staticSiteUrl/" --repo $gitHubRepo --env "${environment}"
+gh variable set "BOOTSTRAP_ADMIN_OBJECT_ID" --body "$bootstrapAdminObjectId" --repo $gitHubRepo --env "${environment}"
+gh variable set "BOOTSTRAP_ADMIN_DISPLAY_NAME" --body "$bootstrapAdminDisplayName" --repo $gitHubRepo --env "${environment}"
 gh secret set "BOOTSTRAP_ADMIN_EMAIL" --body "$bootstrapAdminEmail" --repo $gitHubRepo --env "${environment}"
-gh secret set "BOOTSTRAP_ADMIN_DISPLAY_NAME" --body "$bootstrapAdminDisplayName" --repo $gitHubRepo --env "${environment}"
 
 Write-Host "Configure SonarCloud GitHub Variables and Secrets..." -ForegroundColor Cyan
 gh variable set "SONAR_API_PROJECT_KEY" --body "$sonarApiProjectKey" --repo $gitHubRepo


### PR DESCRIPTION
## Summary

- Converts non-sensitive GitHub Actions config (URLs, IDs, endpoints) from secrets to variables across all workflows and `buildInfrastructure.ps1` — only true credentials remain as secrets
- Adds missing `SQL_DB_NAME` and `SQL_SERVER_NAME` environment variables to the build script (were referenced in CI but never set)
- Removes `TENANT_ID_DEV` — replaced with `vars.TENANT_ID` since the PR preview step always runs under the `dev` environment
- Fixes `freeLimitExhaustionBehavior` on prod SQL database: reads the current value before deploying and passes it as a Bicep parameter to avoid the immutable `BillOverUsage → AutoPause` transition error
- Tightens `create-release` condition to `push` events only and adds branch protection on main requiring `build-api`, `build-ui`, `scan-infra`, and `e2e-tests` to pass before merging

## Test plan

- [ ] Run `buildAllInfrastructure.ps1` — all three environments should complete without error
- [ ] Push a PR and confirm `e2e-tests` is a required check blocking merge
- [ ] Merge to main and confirm `create-release` creates a draft release (and does not trigger on PRs)
- [ ] Publish the release and confirm `release-prod.yml` deploys successfully using `vars.*` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)