### PR TITLE
refactor: make diary service layer async and bound request sizes

### DIFF
--- a/src/api/ccDiaryApi/Controllers/PagingLimits.cs
+++ b/src/api/ccDiaryApi/Controllers/PagingLimits.cs
@@ -1,0 +1,38 @@
+// <copyright file="PagingLimits.cs" company="CookingCode">
+// Copyright (c) CookingCode. All rights reserved.
+// </copyright>
+
+namespace ccDiaryApi.Controllers
+{
+    /// <summary>
+    /// Bounds for paged endpoint query parameters.
+    /// </summary>
+    /// <remarks>
+    /// Paged queries filter in memory, so an unbounded <c>pageSize</c> lets a single
+    /// request materialise an entire table. Callers asking for more than
+    /// <see cref="MaxPageSize"/> get <see cref="MaxPageSize"/> rather than an error.
+    /// </remarks>
+    public static class PagingLimits
+    {
+        /// <summary>The largest page a caller may request.</summary>
+        public const int MaxPageSize = 100;
+
+        /// <summary>Clamps a requested page number to 1 or greater.</summary>
+        /// <param name="page">The requested page number.</param>
+        /// <returns>The page number, floored at 1.</returns>
+        public static int ClampPage(int page) => page < 1 ? 1 : page;
+
+        /// <summary>Clamps a requested page size to the range 1..<see cref="MaxPageSize"/>.</summary>
+        /// <param name="pageSize">The requested page size.</param>
+        /// <returns>The page size, bounded to the permitted range.</returns>
+        public static int ClampPageSize(int pageSize)
+        {
+            if (pageSize < 1)
+            {
+                return 1;
+            }
+
+            return pageSize > MaxPageSize ? MaxPageSize : pageSize;
+        }
+    }
+}

--- a/src/api/ccDiaryApi/Controllers/RequestLimits.cs
+++ b/src/api/ccDiaryApi/Controllers/RequestLimits.cs
@@ -1,0 +1,26 @@
+// <copyright file="RequestLimits.cs" company="CookingCode">
+// Copyright (c) CookingCode. All rights reserved.
+// </copyright>
+
+namespace ccDiaryApi.Controllers
+{
+    /// <summary>
+    /// Explicit request body size limits for the endpoints that accept large payloads.
+    /// </summary>
+    /// <remarks>
+    /// Diary entries embed images as base64, so these endpoints are the only ones that
+    /// can receive a large body. Without an explicit limit they fall back to Kestrel's
+    /// 30 MB default, which is not obvious from the code and leaves no headroom margin
+    /// documented anywhere. The largest real image in the sample data is ~3.3 MB base64
+    /// and the largest real archive is ~25 MB, so both limits below are set to clear
+    /// those with room to spare while still bounding memory on a 0.5 GiB container.
+    /// </remarks>
+    public static class RequestLimits
+    {
+        /// <summary>Maximum body size for a whole-diary archive import.</summary>
+        public const long ArchiveImportBytes = 32L * 1024 * 1024;
+
+        /// <summary>Maximum body size for a single diary entry create or update.</summary>
+        public const long DiaryEntryBytes = 16L * 1024 * 1024;
+    }
+}

--- a/src/api/ccDiaryApi/Controllers/v1/AppInfoController.cs
+++ b/src/api/ccDiaryApi/Controllers/v1/AppInfoController.cs
@@ -24,9 +24,9 @@ namespace ccDiaryApi.Controllers.v1
         }
 
         [HttpGet]
-        public ActionResult<AppInfoDTO> Get()
+        public async Task<ActionResult<AppInfoDTO>> Get()
         {
-            var appInfo = _appInfoService.GetAppInfo();
+            var appInfo = await _appInfoService.GetAppInfoAsync();
             if (appInfo == null)
             {
                 return NotFound();

--- a/src/api/ccDiaryApi/Controllers/v1/DiaryArchiveController.cs
+++ b/src/api/ccDiaryApi/Controllers/v1/DiaryArchiveController.cs
@@ -30,11 +30,11 @@ namespace ccDiaryApi.Controllers.v1
 
         [Route("{diaryId:guid}")]
         [HttpGet]
-        public ActionResult<DiaryArchiveDTO> Export(Guid diaryId)
+        public async Task<ActionResult<DiaryArchiveDTO>> Export(Guid diaryId)
         {
             _logger.LogInformation("Export requested. DiaryId={DiaryId}", SanitizeForLog(diaryId));
 
-            var export = _diaryArchiveService.Export(diaryId);
+            var export = await _diaryArchiveService.ExportAsync(diaryId);
             if (export == null)
             {
                 _logger.LogWarning("Export not found. DiaryId={DiaryId}", SanitizeForLog(diaryId));
@@ -50,7 +50,8 @@ namespace ccDiaryApi.Controllers.v1
 
         [HttpPost]
         [AllowAnonymous]
-        public ActionResult<DiaryDTO> Import([FromServices] IWebHostEnvironment env, DiaryArchiveDTO diaryArchive)
+        [RequestSizeLimit(RequestLimits.ArchiveImportBytes)]
+        public async Task<ActionResult<DiaryDTO>> Import([FromServices] IWebHostEnvironment env, DiaryArchiveDTO diaryArchive)
         {
             bool isLocalEnvironment = env.IsEnvironment("local")
                 || env.IsEnvironment("LocalContainer")
@@ -61,7 +62,7 @@ namespace ccDiaryApi.Controllers.v1
                 return Unauthorized();
             }
 
-            var diary = _diaryArchiveService.Import(diaryArchive);
+            var diary = await _diaryArchiveService.ImportAsync(diaryArchive);
             _logger.LogInformation(
                 "Import succeeded. DiaryId={DiaryId} EntryCount={EntryCount}",
                 SanitizeForLog(diary.DiaryId),

--- a/src/api/ccDiaryApi/Controllers/v1/DiaryController.cs
+++ b/src/api/ccDiaryApi/Controllers/v1/DiaryController.cs
@@ -30,48 +30,51 @@ namespace ccDiaryApi.Controllers.v1
 
         [HttpGet]
         [AllowAnonymous]
-        public ActionResult<PagedResultDTO<DiaryDTO>> Get(
+        public async Task<ActionResult<PagedResultDTO<DiaryDTO>>> Get(
             [FromQuery] int page = 1,
             [FromQuery] int pageSize = 12,
             [FromQuery] string? search = null)
         {
-            var diaries = _diaryService.GetDiaries(page, pageSize, search);
+            var diaries = await _diaryService.GetDiariesAsync(
+                PagingLimits.ClampPage(page),
+                PagingLimits.ClampPageSize(pageSize),
+                search);
             return Ok(diaries);
         }
 
         [Route("{diaryId:guid}")]
         [HttpGet]
         [AllowAnonymous]
-        public ActionResult<DiaryDTO> Get(Guid diaryId)
+        public async Task<ActionResult<DiaryDTO>> Get(Guid diaryId)
         {
-            var diary = _diaryService.GetDiary(diaryId);
+            var diary = await _diaryService.GetDiaryAsync(diaryId);
             return Ok(diary);
         }
 
         [HttpPost]
         [Authorize(Policy = "DiaryContributor")]
-        public ActionResult<DiaryDTO> Create([FromBody] DiaryDTO diary)
+        public async Task<ActionResult<DiaryDTO>> Create([FromBody] DiaryDTO diary)
         {
             diary.OwnerId = User.GetOid();
-            var retDiary = _diaryService.Create(diary);
+            var retDiary = await _diaryService.CreateAsync(diary);
             _logger.LogInformation("Diary created. DiaryId={DiaryId}", SanitizeForLog(retDiary.DiaryId));
             return Created("Uri", retDiary);
         }
 
         [HttpPut]
         [Authorize(Policy = "DiaryContributor")]
-        public ActionResult<DiaryDTO> Update([FromBody] DiaryDTO diary)
+        public async Task<ActionResult<DiaryDTO>> Update([FromBody] DiaryDTO diary)
         {
             if (!User.IsInRole("DiaryAdmin"))
             {
-                var existing = _diaryService.GetDiary(diary.DiaryId ?? Guid.Empty);
+                var existing = await _diaryService.GetDiaryAsync(diary.DiaryId ?? Guid.Empty);
                 if (existing == null || existing.OwnerId != User.GetOid())
                 {
                     return Forbid();
                 }
             }
 
-            var retDiary = _diaryService.Update(diary);
+            var retDiary = await _diaryService.UpdateAsync(diary);
             _logger.LogInformation("Diary updated. DiaryId={DiaryId}", SanitizeForLog(retDiary.DiaryId));
             return Ok(retDiary);
         }
@@ -79,9 +82,9 @@ namespace ccDiaryApi.Controllers.v1
         [Route("{diaryId:guid}")]
         [HttpDelete]
         [Authorize(Policy = "DiaryContributor")]
-        public ActionResult Delete(Guid diaryId)
+        public async Task<ActionResult> Delete(Guid diaryId)
         {
-            var diary = _diaryService.GetDiary(diaryId);
+            var diary = await _diaryService.GetDiaryAsync(diaryId);
             if (diary == null)
             {
                 return NotFound();
@@ -92,7 +95,7 @@ namespace ccDiaryApi.Controllers.v1
                 return Forbid();
             }
 
-            _diaryService.Delete(diary);
+            await _diaryService.DeleteAsync(diary);
             _logger.LogInformation("Diary deleted. DiaryId={DiaryId}", SanitizeForLog(diaryId));
             return Ok();
         }

--- a/src/api/ccDiaryApi/Controllers/v1/DiaryEntryController.cs
+++ b/src/api/ccDiaryApi/Controllers/v1/DiaryEntryController.cs
@@ -37,52 +37,52 @@ namespace ccDiaryApi.Controllers.v1
         [Route("{diaryId:guid}")]
         [AllowAnonymous]
         [HttpGet]
-        public ActionResult<List<int>> Search(Guid diaryId)
+        public async Task<ActionResult<List<int>>> Search(Guid diaryId)
         {
-            var range = _diaryEntryService.GetDiaryDateRange(diaryId);
-            var years = _diaryEntryService.SearchDiaryEntries(diaryId, range.MinDateTime, range.MaxDateTime, SearchType.Year);
+            var range = await _diaryEntryService.GetDiaryDateRangeAsync(diaryId);
+            var years = await _diaryEntryService.SearchDiaryEntriesAsync(diaryId, range.MinDateTime, range.MaxDateTime, SearchType.Year);
             return Ok(years);
         }
 
         [Route("{diaryId:guid}/{year:int}")]
         [AllowAnonymous]
         [HttpGet]
-        public ActionResult<List<int>> Search(Guid diaryId, int year)
+        public async Task<ActionResult<List<int>>> Search(Guid diaryId, int year)
         {
             var from = new DateTime(year, 1, 1, 0, 0, 0, DateTimeKind.Utc);
             var to = from.AddYears(1).Subtract(new TimeSpan(1));
-            var months = _diaryEntryService.SearchDiaryEntries(diaryId, from, to, SearchType.Month);
+            var months = await _diaryEntryService.SearchDiaryEntriesAsync(diaryId, from, to, SearchType.Month);
             return Ok(months);
         }
 
         [Route("{diaryId:guid}/{year:int}/{month:int}")]
         [AllowAnonymous]
         [HttpGet]
-        public ActionResult<List<int>> Search(Guid diaryId, int year, int month, [FromHeader(Name = "x-utc-offset")][DefaultValue(0)] int utcOffsetMinutes)
+        public async Task<ActionResult<List<int>>> Search(Guid diaryId, int year, int month, [FromHeader(Name = "x-utc-offset")][DefaultValue(0)] int utcOffsetMinutes)
         {
             var from = new DateTime(year, month, 1, 0, 0, 0, DateTimeKind.Utc).AddMinutes(-1 * utcOffsetMinutes);
             var to = new DateTime(year, month, 1, 0, 0, 0, DateTimeKind.Utc).AddMonths(1).AddMinutes(-1 * utcOffsetMinutes).Subtract(new TimeSpan(1));
-            var days = _diaryEntryService.SearchDiaryEntries(diaryId, from, to, SearchType.Day, utcOffsetMinutes);
+            var days = await _diaryEntryService.SearchDiaryEntriesAsync(diaryId, from, to, SearchType.Day, utcOffsetMinutes);
             return Ok(days);
         }
 
         [Route("{diaryId:guid}/{year:int}/{month:int}/{day:int}")]
         [AllowAnonymous]
         [HttpGet]
-        public ActionResult<List<DiaryEntryDTO>> Search(Guid diaryId, int year, int month, int day, [FromHeader(Name = "x-utc-offset")][DefaultValue(0)] int utcOffsetMinutes)
+        public async Task<ActionResult<List<DiaryEntryDTO>>> Search(Guid diaryId, int year, int month, int day, [FromHeader(Name = "x-utc-offset")][DefaultValue(0)] int utcOffsetMinutes)
         {
             var from = new DateTime(year, month, day, 0, 0, 0, DateTimeKind.Utc).AddMinutes(-1 * utcOffsetMinutes);
             var to = from.AddDays(1).Subtract(new TimeSpan(1));
-            var searchResult = _diaryEntryService.GetDiaryEntries(diaryId, from.ToUniversalTime(), to.ToUniversalTime());
+            var searchResult = await _diaryEntryService.GetDiaryEntriesAsync(diaryId, from.ToUniversalTime(), to.ToUniversalTime());
             return Ok(searchResult);
         }
 
         [Route("{diaryEntryId:guid}")]
         [AllowAnonymous]
         [HttpGet]
-        public ActionResult<DiaryEntryDTO> Get(Guid diaryEntryId)
+        public async Task<ActionResult<DiaryEntryDTO>> Get(Guid diaryEntryId)
         {
-            var diaryEntry = _diaryEntryService.GetDiaryEntry(diaryEntryId);
+            var diaryEntry = await _diaryEntryService.GetDiaryEntryAsync(diaryEntryId);
             if (diaryEntry == null)
             {
                 return NotFound();
@@ -94,26 +94,27 @@ namespace ccDiaryApi.Controllers.v1
         [Route("{diaryId:guid}")]
         [AllowAnonymous]
         [HttpGet]
-        public ActionResult<IEnumerable<DiaryEntryDTO>> GetDiaryEntries(Guid diaryId)
+        public async Task<ActionResult<IEnumerable<DiaryEntryDTO>>> GetDiaryEntries(Guid diaryId)
         {
-            var diaryEntries = _diaryEntryService.GetDiaryEntries(diaryId);
+            var diaryEntries = await _diaryEntryService.GetDiaryEntriesAsync(diaryId);
             return Ok(diaryEntries);
         }
 
         [HttpPost]
         [Authorize(Policy = "DiaryContributor")]
-        public ActionResult<DiaryEntryDTO> Create([FromBody] DiaryEntryDTO diaryEntry)
+        [RequestSizeLimit(RequestLimits.DiaryEntryBytes)]
+        public async Task<ActionResult<DiaryEntryDTO>> Create([FromBody] DiaryEntryDTO diaryEntry)
         {
             if (!User.IsInRole("DiaryAdmin"))
             {
-                var diary = _diaryService.GetDiary(diaryEntry.DiaryId);
+                var diary = await _diaryService.GetDiaryAsync(diaryEntry.DiaryId);
                 if (diary == null || diary.OwnerId != User.GetOid())
                 {
                     return Forbid();
                 }
             }
 
-            var retDiaryEntry = _diaryEntryService.CreateDiaryEntry(diaryEntry);
+            var retDiaryEntry = await _diaryEntryService.CreateDiaryEntryAsync(diaryEntry);
             _logger.LogInformation(
                 "Diary entry created. DiaryEntryId={DiaryEntryId} DiaryId={DiaryId}",
                 SanitizeForLog(retDiaryEntry.DiaryEntryId),
@@ -123,18 +124,19 @@ namespace ccDiaryApi.Controllers.v1
 
         [HttpPut]
         [Authorize(Policy = "DiaryContributor")]
-        public ActionResult<DiaryEntryDTO> Update([FromBody] DiaryEntryDTO diaryEntry)
+        [RequestSizeLimit(RequestLimits.DiaryEntryBytes)]
+        public async Task<ActionResult<DiaryEntryDTO>> Update([FromBody] DiaryEntryDTO diaryEntry)
         {
             if (!User.IsInRole("DiaryAdmin"))
             {
-                var diary = _diaryService.GetDiary(diaryEntry.DiaryId);
+                var diary = await _diaryService.GetDiaryAsync(diaryEntry.DiaryId);
                 if (diary == null || diary.OwnerId != User.GetOid())
                 {
                     return Forbid();
                 }
             }
 
-            var retDiaryEntry = _diaryEntryService.UpdateDiaryEntry(diaryEntry);
+            var retDiaryEntry = await _diaryEntryService.UpdateDiaryEntryAsync(diaryEntry);
             _logger.LogInformation(
                 "Diary entry updated. DiaryEntryId={DiaryEntryId} DiaryId={DiaryId}",
                 SanitizeForLog(retDiaryEntry.DiaryEntryId),
@@ -145,9 +147,9 @@ namespace ccDiaryApi.Controllers.v1
         [Route("{diaryEntryId:guid}")]
         [HttpDelete]
         [Authorize(Policy = "DiaryContributor")]
-        public ActionResult Delete(Guid diaryEntryId)
+        public async Task<ActionResult> Delete(Guid diaryEntryId)
         {
-            var diaryEntry = _diaryEntryService.GetDiaryEntry(diaryEntryId);
+            var diaryEntry = await _diaryEntryService.GetDiaryEntryAsync(diaryEntryId);
             if (diaryEntry == null)
             {
                 return NotFound();
@@ -155,14 +157,14 @@ namespace ccDiaryApi.Controllers.v1
 
             if (!User.IsInRole("DiaryAdmin"))
             {
-                var diary = _diaryService.GetDiary(diaryEntry.DiaryId);
+                var diary = await _diaryService.GetDiaryAsync(diaryEntry.DiaryId);
                 if (diary == null || diary.OwnerId != User.GetOid())
                 {
                     return Forbid();
                 }
             }
 
-            _diaryEntryService.DeleteDiaryEntry(diaryEntry);
+            await _diaryEntryService.DeleteDiaryEntryAsync(diaryEntry);
             _logger.LogInformation(
                 "Diary entry deleted. DiaryEntryId={DiaryEntryId}",
                 SanitizeForLog(diaryEntryId));
@@ -172,7 +174,7 @@ namespace ccDiaryApi.Controllers.v1
         [Route("{diaryId:guid}")]
         [AllowAnonymous]
         [HttpGet]
-        public ActionResult<PagedResultDTO<DiaryEntryDTO>> TextSearch(
+        public async Task<ActionResult<PagedResultDTO<DiaryEntryDTO>>> TextSearch(
             Guid diaryId,
             [FromQuery] string search,
             [FromQuery] int page = 1,
@@ -183,25 +185,29 @@ namespace ccDiaryApi.Controllers.v1
                 return BadRequest("search is required");
             }
 
-            var results = _diaryEntryService.TextSearchDiaryEntries(diaryId, search, page, pageSize);
+            var results = await _diaryEntryService.TextSearchDiaryEntriesAsync(
+                diaryId,
+                search,
+                PagingLimits.ClampPage(page),
+                PagingLimits.ClampPageSize(pageSize));
             return Ok(results);
         }
 
         [Route("{diaryId:guid}")]
         [AllowAnonymous]
         [HttpGet]
-        public ActionResult<DateTime> GetMinDate(Guid diaryId)
+        public async Task<ActionResult<DateTime>> GetMinDate(Guid diaryId)
         {
-            var date = _diaryEntryService.MinDiaryEntryDate(diaryId);
+            var date = await _diaryEntryService.MinDiaryEntryDateAsync(diaryId);
             return Ok(date);
         }
 
         [Route("{diaryId:guid}")]
         [AllowAnonymous]
         [HttpGet]
-        public ActionResult<DateTime> GetMaxDate(Guid diaryId)
+        public async Task<ActionResult<DateTime>> GetMaxDate(Guid diaryId)
         {
-            var date = _diaryEntryService.MaxDiaryEntryDate(diaryId);
+            var date = await _diaryEntryService.MaxDiaryEntryDateAsync(diaryId);
             return Ok(date);
         }
 

--- a/src/api/ccDiaryApi/Services/AppInfoService.cs
+++ b/src/api/ccDiaryApi/Services/AppInfoService.cs
@@ -6,6 +6,7 @@ namespace ccDiaryApi.Services
 {
     using ccDiaryApi.Data.Context;
     using ccDiaryApi.Data.Model;
+    using Microsoft.EntityFrameworkCore;
 
     public class AppInfoService : IAppInfoService
     {
@@ -16,9 +17,9 @@ namespace ccDiaryApi.Services
             _context = context;
         }
 
-        public AppInfoDTO? GetAppInfo()
+        public async Task<AppInfoDTO?> GetAppInfoAsync()
         {
-            return _context.AppInfo.SingleOrDefault(a => a.Id == 1);
+            return await _context.AppInfo.SingleOrDefaultAsync(a => a.Id == 1);
         }
     }
 }

--- a/src/api/ccDiaryApi/Services/DiaryArchiveService.cs
+++ b/src/api/ccDiaryApi/Services/DiaryArchiveService.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DiaryArchiveService.cs" company="CookingCode">
+// <copyright file="DiaryArchiveService.cs" company="CookingCode">
 // Copyright (c) CookingCode. All rights reserved.
 // </copyright>
 
@@ -6,6 +6,7 @@ namespace ccDiaryApi.Services
 {
     using ccDiaryApi.Data.Context;
     using ccDiaryApi.Data.Model;
+    using Microsoft.EntityFrameworkCore;
 
     public class DiaryArchiveService : IDiaryArchiveService
     {
@@ -16,21 +17,21 @@ namespace ccDiaryApi.Services
             _context = context;
         }
 
-        public DiaryArchiveDTO? Export(Guid diaryId)
+        public async Task<DiaryArchiveDTO?> ExportAsync(Guid diaryId)
         {
-            var diary = _context.Diaries.Where(x => x.DiaryId == diaryId).FirstOrDefault();
+            var diary = await _context.Diaries.Where(x => x.DiaryId == diaryId).FirstOrDefaultAsync();
             if (diary == null)
             {
                 return null;
             }
 
-            var diaryEntries = _context.DiaryEntries.Where(x => x.DiaryId == diaryId).OrderBy(x => x.Date).ToList();
+            var diaryEntries = await _context.DiaryEntries.Where(x => x.DiaryId == diaryId).OrderBy(x => x.Date).ToListAsync();
             return new DiaryArchiveDTO { Diary = diary, DiaryEntries = diaryEntries };
         }
 
-        public DiaryDTO Import(DiaryArchiveDTO diaryArchive)
+        public async Task<DiaryDTO> ImportAsync(DiaryArchiveDTO diaryArchive)
         {
-            var diary = _context.Diaries.Where(x => x.DiaryId == diaryArchive.Diary.DiaryId).FirstOrDefault();
+            var diary = await _context.Diaries.Where(x => x.DiaryId == diaryArchive.Diary.DiaryId).FirstOrDefaultAsync();
 
             if (diary == null)
             {
@@ -46,7 +47,7 @@ namespace ccDiaryApi.Services
 
             foreach (var diaryEntry in diaryArchive.DiaryEntries)
             {
-                var updateDiaryEntry = _context.DiaryEntries.Where(x => x.DiaryEntryId == diaryEntry.DiaryEntryId).FirstOrDefault();
+                var updateDiaryEntry = await _context.DiaryEntries.Where(x => x.DiaryEntryId == diaryEntry.DiaryEntryId).FirstOrDefaultAsync();
                 if (updateDiaryEntry == null)
                 {
                     _context.Add(diaryEntry);
@@ -68,7 +69,7 @@ namespace ccDiaryApi.Services
                 }
             }
 
-            _context.SaveChanges();
+            await _context.SaveChangesAsync();
             return diaryArchive.Diary;
         }
     }

--- a/src/api/ccDiaryApi/Services/DiaryEntryService.cs
+++ b/src/api/ccDiaryApi/Services/DiaryEntryService.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DiaryEntryService.cs" company="CookingCode">
+// <copyright file="DiaryEntryService.cs" company="CookingCode">
 // Copyright (c) CookingCode. All rights reserved.
 // </copyright>
 
@@ -6,6 +6,7 @@ namespace ccDiaryApi.Services
 {
     using ccDiaryApi.Data.Context;
     using ccDiaryApi.Data.Model;
+    using Microsoft.EntityFrameworkCore;
 
     public class DiaryEntryService : IDiaryEntryService
     {
@@ -16,7 +17,7 @@ namespace ccDiaryApi.Services
             _context = context;
         }
 
-        public DiaryEntryDTO CreateDiaryEntry(DiaryEntryDTO diaryEntry)
+        public async Task<DiaryEntryDTO> CreateDiaryEntryAsync(DiaryEntryDTO diaryEntry)
         {
             if (diaryEntry.Date == null || diaryEntry.Date == DateTime.MinValue)
             {
@@ -24,34 +25,34 @@ namespace ccDiaryApi.Services
             }
 
             _context.Add(diaryEntry);
-            _context.SaveChanges();
+            await _context.SaveChangesAsync();
             return diaryEntry;
         }
 
-        public void DeleteDiaryEntry(DiaryEntryDTO diaryEntry)
+        public async Task DeleteDiaryEntryAsync(DiaryEntryDTO diaryEntry)
         {
             _context.Remove(diaryEntry);
-            _context.SaveChanges();
+            await _context.SaveChangesAsync();
         }
 
-        public DiaryDateRange GetDiaryDateRange(Guid diaryId)
+        public async Task<DiaryDateRange> GetDiaryDateRangeAsync(Guid diaryId)
         {
-            var maxDate = _context.DiaryEntries
+            var maxDate = await _context.DiaryEntries
                 .Where(d => d.DiaryId == diaryId)
                 .OrderByDescending(d => d.Date)
-                .Select(d => d.Date).AsEnumerable()
-                .FirstOrDefault() ?? DateTime.MaxValue;
+                .Select(d => d.Date)
+                .FirstOrDefaultAsync() ?? DateTime.MaxValue;
 
-            var minDate = _context.DiaryEntries
+            var minDate = await _context.DiaryEntries
                 .Where(d => d.DiaryId == diaryId)
                 .OrderBy(d => d.Date)
-                .Select(d => d.Date).AsEnumerable()
-                .FirstOrDefault() ?? DateTime.MinValue;
+                .Select(d => d.Date)
+                .FirstOrDefaultAsync() ?? DateTime.MinValue;
 
             return new DiaryDateRange { MaxDateTime = maxDate, MinDateTime = minDate };
         }
 
-        public List<int> SearchDiaryEntries(Guid diaryId, DateTime from, DateTime until, SearchType searchType, int utcOffsetMinutes = 0)
+        public async Task<List<int>> SearchDiaryEntriesAsync(Guid diaryId, DateTime from, DateTime until, SearchType searchType, int utcOffsetMinutes = 0)
         {
             Func<DiaryEntryDTO, int> func;
             switch (searchType)
@@ -69,43 +70,48 @@ namespace ccDiaryApi.Services
                     throw new ArgumentException($"Unhandled SearchType [{searchType}]");
             }
 
-            return _context.DiaryEntries.Where(x => x.DiaryId == diaryId && x.Date >= from && x.Date <= until)
+            // The projection runs client-side: only the Where is translated to SQL.
+            var matches = await _context.DiaryEntries
+                .Where(x => x.DiaryId == diaryId && x.Date >= from && x.Date <= until)
+                .ToListAsync();
+
+            return matches
                 .OrderBy(func)
                 .Select(func)
                 .Distinct()
                 .ToList();
         }
 
-        public List<DiaryEntryDTO> GetDiaryEntries(Guid diaryId)
+        public async Task<List<DiaryEntryDTO>> GetDiaryEntriesAsync(Guid diaryId)
         {
-            return _context.DiaryEntries
+            return await _context.DiaryEntries
                 .Where(x => x.DiaryId == diaryId)
                 .OrderBy(x => x.Date)
-                .ToList();
+                .ToListAsync();
         }
 
-        public List<DiaryEntryDTO> GetDiaryEntries(Guid diaryId, DateTime from, DateTime until)
+        public async Task<List<DiaryEntryDTO>> GetDiaryEntriesAsync(Guid diaryId, DateTime from, DateTime until)
         {
-            return _context.DiaryEntries
+            return await _context.DiaryEntries
                 .Where(x => x.DiaryId == diaryId && x.Date >= from && x.Date <= until)
                 .OrderBy(x => x.Date)
-                .ToList();
+                .ToListAsync();
         }
 
-        public DiaryEntryDTO? GetDiaryEntry(Guid id)
+        public async Task<DiaryEntryDTO?> GetDiaryEntryAsync(Guid id)
         {
-            return _context.DiaryEntries.Where(x => x.DiaryEntryId == id)
-                .FirstOrDefault();
+            return await _context.DiaryEntries.Where(x => x.DiaryEntryId == id)
+                .FirstOrDefaultAsync();
         }
 
-        public DiaryEntryDTO UpdateDiaryEntry(DiaryEntryDTO diaryEntry)
+        public async Task<DiaryEntryDTO> UpdateDiaryEntryAsync(DiaryEntryDTO diaryEntry)
         {
             _context.Update(diaryEntry);
-            _context.SaveChanges();
+            await _context.SaveChangesAsync();
             return diaryEntry;
         }
 
-        public PagedResultDTO<DiaryEntryDTO> TextSearchDiaryEntries(Guid diaryId, string search, int page = 1, int pageSize = 20)
+        public async Task<PagedResultDTO<DiaryEntryDTO>> TextSearchDiaryEntriesAsync(Guid diaryId, string search, int page = 1, int pageSize = 20)
         {
             var query = _context.DiaryEntries
                 .Where(x => x.DiaryId == diaryId)
@@ -114,10 +120,10 @@ namespace ccDiaryApi.Services
                             (x.FromLocation != null && x.FromLocation.Contains(search)) ||
                             (x.ToLocation != null && x.ToLocation.Contains(search)));
 
-            var totalCount = query.Count();
-            var items = query
+            var totalCount = await query.CountAsync();
+            var items = await query
                 .OrderBy(x => x.Date)
-                .Skip((page - 1) * pageSize).Take(pageSize).ToList();
+                .Skip((page - 1) * pageSize).Take(pageSize).ToListAsync();
 
             return new PagedResultDTO<DiaryEntryDTO>
             {
@@ -128,28 +134,28 @@ namespace ccDiaryApi.Services
             };
         }
 
-        public DateTime MinDiaryEntryDate(Guid diaryId)
+        public async Task<DateTime> MinDiaryEntryDateAsync(Guid diaryId)
         {
-            if (!_context.DiaryEntries.Any(x => x.DiaryId == diaryId))
+            if (!await _context.DiaryEntries.AnyAsync(x => x.DiaryId == diaryId))
             {
                 return DateTime.UtcNow;
             }
 
-            return _context.DiaryEntries
+            return await _context.DiaryEntries
                 .Where(x => x.DiaryId == diaryId)
-                .Min(x => x.Date) ?? DateTime.MinValue;
+                .MinAsync(x => x.Date) ?? DateTime.MinValue;
         }
 
-        public DateTime MaxDiaryEntryDate(Guid diaryId)
+        public async Task<DateTime> MaxDiaryEntryDateAsync(Guid diaryId)
         {
-            if (!_context.DiaryEntries.Any(x => x.DiaryId == diaryId))
+            if (!await _context.DiaryEntries.AnyAsync(x => x.DiaryId == diaryId))
             {
                 return DateTime.UtcNow;
             }
 
-            return _context.DiaryEntries
+            return await _context.DiaryEntries
                 .Where(x => x.DiaryId == diaryId)
-                .Max(x => x.Date) ?? DateTime.MaxValue;
+                .MaxAsync(x => x.Date) ?? DateTime.MaxValue;
         }
     }
 }

--- a/src/api/ccDiaryApi/Services/DiaryService.cs
+++ b/src/api/ccDiaryApi/Services/DiaryService.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DiaryService.cs" company="CookingCode">
+// <copyright file="DiaryService.cs" company="CookingCode">
 // Copyright (c) CookingCode. All rights reserved.
 // </copyright>
 
@@ -6,6 +6,7 @@ namespace ccDiaryApi.Services
 {
     using ccDiaryApi.Data.Context;
     using ccDiaryApi.Data.Model;
+    using Microsoft.EntityFrameworkCore;
 
     public class DiaryService : IDiaryService
     {
@@ -16,20 +17,20 @@ namespace ccDiaryApi.Services
             _context = context;
         }
 
-        public DiaryDTO Create(DiaryDTO diary)
+        public async Task<DiaryDTO> CreateAsync(DiaryDTO diary)
         {
             _context.Add(diary);
-            _context.SaveChanges();
+            await _context.SaveChangesAsync();
             return diary;
         }
 
-        public void Delete(DiaryDTO diary)
+        public async Task DeleteAsync(DiaryDTO diary)
         {
             _context.Remove(diary);
-            _context.SaveChanges();
+            await _context.SaveChangesAsync();
         }
 
-        public PagedResultDTO<DiaryDTO> GetDiaries(int page, int pageSize, string? search = null)
+        public async Task<PagedResultDTO<DiaryDTO>> GetDiariesAsync(int page, int pageSize, string? search = null)
         {
             var query = _context.Diaries.AsQueryable();
             if (!string.IsNullOrWhiteSpace(search))
@@ -38,10 +39,10 @@ namespace ccDiaryApi.Services
                                          (x.Description != null && x.Description.Contains(search)));
             }
 
-            var totalCount = query.Count();
-            var items = query
+            var totalCount = await query.CountAsync();
+            var items = await query
                 .OrderBy(x => x.Author).ThenBy(x => x.Title)
-                .Skip((page - 1) * pageSize).Take(pageSize).ToList();
+                .Skip((page - 1) * pageSize).Take(pageSize).ToListAsync();
             return new PagedResultDTO<DiaryDTO>
             {
                 Items = items,
@@ -51,17 +52,17 @@ namespace ccDiaryApi.Services
             };
         }
 
-        public DiaryDTO? GetDiary(Guid diaryId)
+        public async Task<DiaryDTO?> GetDiaryAsync(Guid diaryId)
         {
-            var diary = _context.Diaries
-                .SingleOrDefault(x => x.DiaryId == diaryId);
+            var diary = await _context.Diaries
+                .SingleOrDefaultAsync(x => x.DiaryId == diaryId);
             return diary;
         }
 
-        public DiaryDTO Update(DiaryDTO diary)
+        public async Task<DiaryDTO> UpdateAsync(DiaryDTO diary)
         {
             _context.Update(diary);
-            _context.SaveChanges();
+            await _context.SaveChangesAsync();
             return diary;
         }
     }

--- a/src/api/ccDiaryApi/Services/IAppInfoService.cs
+++ b/src/api/ccDiaryApi/Services/IAppInfoService.cs
@@ -8,6 +8,6 @@ namespace ccDiaryApi.Services
 
     public interface IAppInfoService
     {
-        AppInfoDTO? GetAppInfo();
+        Task<AppInfoDTO?> GetAppInfoAsync();
     }
 }

--- a/src/api/ccDiaryApi/Services/IDiaryArchiveService.cs
+++ b/src/api/ccDiaryApi/Services/IDiaryArchiveService.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="IDiaryArchiveService.cs" company="CookingCode">
+// <copyright file="IDiaryArchiveService.cs" company="CookingCode">
 // Copyright (c) CookingCode. All rights reserved.
 // </copyright>
 
@@ -8,8 +8,8 @@ namespace ccDiaryApi.Services
 
     public interface IDiaryArchiveService
     {
-        DiaryArchiveDTO? Export(Guid diaryId);
+        Task<DiaryArchiveDTO?> ExportAsync(Guid diaryId);
 
-        DiaryDTO Import(DiaryArchiveDTO diaryArchive);
+        Task<DiaryDTO> ImportAsync(DiaryArchiveDTO diaryArchive);
     }
 }

--- a/src/api/ccDiaryApi/Services/IDiaryEntryService.cs
+++ b/src/api/ccDiaryApi/Services/IDiaryEntryService.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="IDiaryEntryService.cs" company="CookingCode">
+// <copyright file="IDiaryEntryService.cs" company="CookingCode">
 // Copyright (c) CookingCode. All rights reserved.
 // </copyright>
 
@@ -8,26 +8,26 @@ namespace ccDiaryApi.Services
 
     public interface IDiaryEntryService
     {
-        List<int> SearchDiaryEntries(Guid diaryId, DateTime from, DateTime until, SearchType searchType, int utcOffsetMinutes = 0);
+        Task<List<int>> SearchDiaryEntriesAsync(Guid diaryId, DateTime from, DateTime until, SearchType searchType, int utcOffsetMinutes = 0);
 
-        List<DiaryEntryDTO> GetDiaryEntries(Guid diaryId, DateTime from, DateTime until);
+        Task<List<DiaryEntryDTO>> GetDiaryEntriesAsync(Guid diaryId, DateTime from, DateTime until);
 
-        List<DiaryEntryDTO> GetDiaryEntries(Guid diaryId);
+        Task<List<DiaryEntryDTO>> GetDiaryEntriesAsync(Guid diaryId);
 
-        DiaryEntryDTO? GetDiaryEntry(Guid id);
+        Task<DiaryEntryDTO?> GetDiaryEntryAsync(Guid id);
 
-        DiaryDateRange GetDiaryDateRange(Guid diaryId);
+        Task<DiaryDateRange> GetDiaryDateRangeAsync(Guid diaryId);
 
-        void DeleteDiaryEntry(DiaryEntryDTO diaryEntry);
+        Task DeleteDiaryEntryAsync(DiaryEntryDTO diaryEntry);
 
-        DiaryEntryDTO CreateDiaryEntry(DiaryEntryDTO diaryEntry);
+        Task<DiaryEntryDTO> CreateDiaryEntryAsync(DiaryEntryDTO diaryEntry);
 
-        DiaryEntryDTO UpdateDiaryEntry(DiaryEntryDTO diaryEntry);
+        Task<DiaryEntryDTO> UpdateDiaryEntryAsync(DiaryEntryDTO diaryEntry);
 
-        DateTime MinDiaryEntryDate(Guid diaryId);
+        Task<DateTime> MinDiaryEntryDateAsync(Guid diaryId);
 
-        DateTime MaxDiaryEntryDate(Guid diaryId);
+        Task<DateTime> MaxDiaryEntryDateAsync(Guid diaryId);
 
-        PagedResultDTO<DiaryEntryDTO> TextSearchDiaryEntries(Guid diaryId, string search, int page = 1, int pageSize = 20);
+        Task<PagedResultDTO<DiaryEntryDTO>> TextSearchDiaryEntriesAsync(Guid diaryId, string search, int page = 1, int pageSize = 20);
     }
 }

--- a/src/api/ccDiaryApi/Services/IDiaryService.cs
+++ b/src/api/ccDiaryApi/Services/IDiaryService.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="IDiaryService.cs" company="CookingCode">
+// <copyright file="IDiaryService.cs" company="CookingCode">
 // Copyright (c) CookingCode. All rights reserved.
 // </copyright>
 
@@ -8,14 +8,14 @@ namespace ccDiaryApi.Services
 
     public interface IDiaryService
     {
-        PagedResultDTO<DiaryDTO> GetDiaries(int page, int pageSize, string? search = null);
+        Task<PagedResultDTO<DiaryDTO>> GetDiariesAsync(int page, int pageSize, string? search = null);
 
-        DiaryDTO? GetDiary(Guid diaryId);
+        Task<DiaryDTO?> GetDiaryAsync(Guid diaryId);
 
-        DiaryDTO Create(DiaryDTO diary);
+        Task<DiaryDTO> CreateAsync(DiaryDTO diary);
 
-        DiaryDTO Update(DiaryDTO diary);
+        Task<DiaryDTO> UpdateAsync(DiaryDTO diary);
 
-        void Delete(DiaryDTO diary);
+        Task DeleteAsync(DiaryDTO diary);
     }
 }

--- a/src/api/ccDiaryApiTest/v1/AppInfoControllerTest.cs
+++ b/src/api/ccDiaryApiTest/v1/AppInfoControllerTest.cs
@@ -5,33 +5,30 @@
 namespace ccDiaryApiTest.v1
 {
     using ccDiaryApi.Controllers.v1;
-    using ccDiaryApi.Data.Context;
     using ccDiaryApi.Data.Model;
     using ccDiaryApi.Services;
     using Microsoft.AspNetCore.Mvc;
-    using Microsoft.EntityFrameworkCore;
+    using Moq;
 
     [TestClass]
     public class AppInfoControllerTest
     {
         [TestMethod]
-        public void Get_ReturnsOk_WhenAppInfoExists()
+        public async Task Get_ReturnsOk_WhenAppInfoExists()
         {
             // Arrange
-            var db = GetMemoryContext("AppInfoTest_Ok_" + Guid.NewGuid());
-            db.AppInfo.Add(new AppInfoDTO
+            var appInfo = new AppInfoDTO
             {
                 Id = 1,
                 InformationalVersion = "1.2.3",
                 DatabaseLastUpdated = DateTime.UtcNow,
-            });
-            db.SaveChanges();
-
-            var service = new AppInfoService(db);
-            var controller = new AppInfoController(service);
+            };
+            var service = new Mock<IAppInfoService>();
+            service.Setup(x => x.GetAppInfoAsync()).ReturnsAsync(appInfo);
+            var controller = new AppInfoController(service.Object);
 
             // Act
-            var response = controller.Get();
+            var response = await controller.Get();
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
@@ -41,26 +38,18 @@ namespace ccDiaryApiTest.v1
         }
 
         [TestMethod]
-        public void Get_ReturnsNotFound_WhenAppInfoIsNull()
+        public async Task Get_ReturnsNotFound_WhenAppInfoIsNull()
         {
             // Arrange
-            var db = GetMemoryContext("AppInfoTest_NotFound_" + Guid.NewGuid());
-            var service = new AppInfoService(db);
-            var controller = new AppInfoController(service);
+            var service = new Mock<IAppInfoService>();
+            service.Setup(x => x.GetAppInfoAsync()).ReturnsAsync((AppInfoDTO?)null);
+            var controller = new AppInfoController(service.Object);
 
             // Act
-            var response = controller.Get();
+            var response = await controller.Get();
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(NotFoundResult));
-        }
-
-        private static DiaryDatabaseContext GetMemoryContext(string dbName)
-        {
-            var options = new DbContextOptionsBuilder<DiaryDatabaseContext>()
-                .UseInMemoryDatabase(databaseName: dbName)
-                .Options;
-            return new DiaryDatabaseContext(options);
         }
     }
 }

--- a/src/api/ccDiaryApiTest/v1/DiaryArchiveControllerTest.cs
+++ b/src/api/ccDiaryApiTest/v1/DiaryArchiveControllerTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DiaryArchiveControllerTest.cs" company="CookingCode">
+// <copyright file="DiaryArchiveControllerTest.cs" company="CookingCode">
 // Copyright (c) CookingCode. All rights reserved.
 // </copyright>
 
@@ -7,178 +7,144 @@ namespace ccDiaryApiTest.v1
     using System;
     using System.Security.Claims;
     using ccDiaryApi.Controllers.v1;
-    using ccDiaryApi.Data.Context;
     using ccDiaryApi.Data.Model;
     using ccDiaryApi.Services;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
-    using Microsoft.EntityFrameworkCore;
     using Moq;
 
     [TestClass]
     public class DiaryArchiveControllerTest
     {
-        public static DiaryDatabaseContext GetMemoryContext()
-        {
-            var options = new DbContextOptionsBuilder<DiaryDatabaseContext>()
-                .UseInMemoryDatabase(databaseName: "InMemoryDatabase")
-                .EnableSensitiveDataLogging()
-                .Options;
-            return new DiaryDatabaseContext(options);
-        }
+        private Mock<IDiaryArchiveService> _archiveService = null!;
 
         [TestInitialize]
-        public void InitDb()
+        public void Init()
         {
-            var db = GetMemoryContext();
-            if (db.Database.IsInMemory())
-            {
-                db.Database.EnsureDeleted();
-            }
+            _archiveService = new Mock<IDiaryArchiveService>();
         }
 
         [TestMethod]
-        public void Export()
+        public async Task Export()
         {
             // Arrange
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
-            var diaryEntryService = new DiaryEntryService(db);
-            var diaryArchiveService = new DiaryArchiveService(db);
-            var controller = new DiaryArchiveController(diaryArchiveService);
-
-            var diary = diaryService.Create(new DiaryDTO()
+            var diaryId = Guid.NewGuid();
+            var archive = new DiaryArchiveDTO
             {
-                Author = "TestAuthor",
-                Title = "TestDiary",
-                Description = "TestDescription",
-            });
-
-            diaryEntryService.CreateDiaryEntry(new DiaryEntryDTO()
-            {
-                Entry = "TestEntryA",
-                Date = DateTime.Now,
-                Location = "TestLocationA",
-                DiaryId = diary.DiaryId!.Value,
-            });
-
-            diaryEntryService.CreateDiaryEntry(new DiaryEntryDTO()
-            {
-                Entry = "TestEntryB",
-                Date = DateTime.Now,
-                Location = "TestLocationB",
-                DiaryId = diary.DiaryId!.Value,
-            });
+                Diary = new DiaryDTO
+                {
+                    DiaryId = diaryId,
+                    Author = "TestAuthor",
+                    Title = "TestDiary",
+                    Description = "TestDescription",
+                },
+                DiaryEntries = new List<DiaryEntryDTO>
+                {
+                    new () { Entry = "TestEntryA", Date = DateTime.UtcNow, Location = "TestLocationA", DiaryId = diaryId },
+                    new () { Entry = "TestEntryB", Date = DateTime.UtcNow, Location = "TestLocationB", DiaryId = diaryId },
+                },
+            };
+            _archiveService.Setup(x => x.ExportAsync(diaryId)).ReturnsAsync(archive);
+            var controller = new DiaryArchiveController(_archiveService.Object);
 
             // Act
-            var response = controller.Export(diary.DiaryId!.Value);
+            var response = await controller.Export(diaryId);
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
             var result = response.GetObjectResult();
             Assert.IsNotNull(result);
-            Assert.AreEqual(diary.DiaryId, result.Diary.DiaryId);
+            Assert.AreEqual(diaryId, result.Diary.DiaryId);
             Assert.AreEqual(2, result.DiaryEntries.Count);
         }
 
         [TestMethod]
-        public void ExportDiaryNotFound()
+        public async Task ExportDiaryNotFound()
         {
             // Arrange
-            var db = GetMemoryContext();
-            var diaryArchiveService = new DiaryArchiveService(db);
-            var controller = new DiaryArchiveController(diaryArchiveService);
+            _archiveService.Setup(x => x.ExportAsync(It.IsAny<Guid>())).ReturnsAsync((DiaryArchiveDTO?)null);
+            var controller = new DiaryArchiveController(_archiveService.Object);
 
             // Act
-            var response = controller.Export(Guid.NewGuid());
+            var response = await controller.Export(Guid.NewGuid());
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(NotFoundResult));
         }
 
         [TestMethod]
-        public void Import_NonLocalEnvironment_Unauthenticated_ReturnsUnauthorized()
+        public async Task Import_NonLocalEnvironment_Unauthenticated_ReturnsUnauthorized()
         {
             // Arrange
-            var db = GetMemoryContext();
-            var controller = new DiaryArchiveController(new DiaryArchiveService(db));
-            var env = new Mock<IWebHostEnvironment>();
-            env.Setup(e => e.EnvironmentName).Returns("Production");
-            controller.ControllerContext = new ControllerContext
-            {
-                HttpContext = new DefaultHttpContext
-                {
-                    User = new ClaimsPrincipal(new ClaimsIdentity()),
-                },
-            };
+            var controller = CreateControllerWithAnonymousUser();
+            var env = MockEnvironment("Production");
 
             // Act
-            var archive = new DiaryArchiveDTO
-            {
-                Diary = new DiaryDTO { Author = "A", Title = "T", Description = "D" },
-                DiaryEntries = new List<DiaryEntryDTO>(),
-            };
-            var result = controller.Import(env.Object, archive);
+            var result = await controller.Import(env, NewArchive());
 
             // Assert
             Assert.IsInstanceOfType(result.Result, typeof(UnauthorizedResult));
+            _archiveService.Verify(x => x.ImportAsync(It.IsAny<DiaryArchiveDTO>()), Times.Never);
         }
 
         [TestMethod]
-        public void Import_LocalEnvironment_Unauthenticated_ReturnsOk()
+        public async Task Import_LocalEnvironment_Unauthenticated_ReturnsOk()
         {
             // Arrange
-            var db = GetMemoryContext();
-            var controller = new DiaryArchiveController(new DiaryArchiveService(db));
-            var env = new Mock<IWebHostEnvironment>();
-            env.Setup(e => e.EnvironmentName).Returns("local");
-            controller.ControllerContext = new ControllerContext
-            {
-                HttpContext = new DefaultHttpContext
-                {
-                    User = new ClaimsPrincipal(new ClaimsIdentity()),
-                },
-            };
-            var archive = new DiaryArchiveDTO
-            {
-                Diary = new DiaryDTO { Author = "Author", Title = "Title", Description = "Desc" },
-                DiaryEntries = new List<DiaryEntryDTO>(),
-            };
+            var archive = NewArchive();
+            _archiveService.Setup(x => x.ImportAsync(archive)).ReturnsAsync(archive.Diary);
+            var controller = CreateControllerWithAnonymousUser();
+            var env = MockEnvironment("local");
 
             // Act
-            var result = controller.Import(env.Object, archive);
+            var result = await controller.Import(env, archive);
 
             // Assert
             Assert.IsInstanceOfType(result.Result, typeof(OkObjectResult));
         }
 
         [TestMethod]
-        public void Import_LocalContainerEnvironment_Unauthenticated_ReturnsOk()
+        public async Task Import_LocalContainerEnvironment_Unauthenticated_ReturnsOk()
         {
             // Arrange — covers the env.IsEnvironment("LocalContainer") == true branch
-            var db = GetMemoryContext();
-            var controller = new DiaryArchiveController(new DiaryArchiveService(db));
-            var env = new Mock<IWebHostEnvironment>();
-            env.Setup(e => e.EnvironmentName).Returns("LocalContainer");
-            controller.ControllerContext = new ControllerContext
-            {
-                HttpContext = new DefaultHttpContext
-                {
-                    User = new ClaimsPrincipal(new ClaimsIdentity()),
-                },
-            };
-            var archive = new DiaryArchiveDTO
-            {
-                Diary = new DiaryDTO { Author = "Author", Title = "Title", Description = "Desc" },
-                DiaryEntries = new List<DiaryEntryDTO>(),
-            };
+            var archive = NewArchive();
+            _archiveService.Setup(x => x.ImportAsync(archive)).ReturnsAsync(archive.Diary);
+            var controller = CreateControllerWithAnonymousUser();
+            var env = MockEnvironment("LocalContainer");
 
             // Act
-            var result = controller.Import(env.Object, archive);
+            var result = await controller.Import(env, archive);
 
             // Assert
             Assert.IsInstanceOfType(result.Result, typeof(OkObjectResult));
+        }
+
+        private static IWebHostEnvironment MockEnvironment(string environmentName)
+        {
+            var env = new Mock<IWebHostEnvironment>();
+            env.Setup(e => e.EnvironmentName).Returns(environmentName);
+            return env.Object;
+        }
+
+        private static DiaryArchiveDTO NewArchive() => new ()
+        {
+            Diary = new DiaryDTO { Author = "Author", Title = "Title", Description = "Desc" },
+            DiaryEntries = new List<DiaryEntryDTO>(),
+        };
+
+        private DiaryArchiveController CreateControllerWithAnonymousUser()
+        {
+            return new DiaryArchiveController(_archiveService.Object)
+            {
+                ControllerContext = new ControllerContext
+                {
+                    HttpContext = new DefaultHttpContext
+                    {
+                        User = new ClaimsPrincipal(new ClaimsIdentity()),
+                    },
+                },
+            };
         }
     }
 }

--- a/src/api/ccDiaryApiTest/v1/DiaryControllerTest.cs
+++ b/src/api/ccDiaryApiTest/v1/DiaryControllerTest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DiaryControllerTest.cs" company="CookingCode">
+// <copyright file="DiaryControllerTest.cs" company="CookingCode">
 // Copyright (c) CookingCode. All rights reserved.
 // </copyright>
 
@@ -8,49 +8,45 @@ namespace ccDiaryApiTest.v1
     using System.Collections.Generic;
     using System.Linq;
     using System.Security.Claims;
-    using System.Text;
     using System.Threading.Tasks;
+    using ccDiaryApi.Controllers;
     using ccDiaryApi.Controllers.v1;
-    using ccDiaryApi.Data.Context;
     using ccDiaryApi.Data.Model;
     using ccDiaryApi.Services;
     using Microsoft.AspNetCore.Http;
-    using Microsoft.AspNetCore.Http.HttpResults;
     using Microsoft.AspNetCore.Mvc;
-    using Microsoft.EntityFrameworkCore;
+    using Moq;
 
+    /// <summary>
+    /// Controller-level tests: routing of results, authorisation branches and query
+    /// parameter clamping. The query semantics of <see cref="DiaryService"/> itself
+    /// are covered by the integration tests, which run it end to end over HTTP.
+    /// </summary>
     [TestClass]
     public class DiaryControllerTest
     {
-        public static DiaryDatabaseContext GetMemoryContext()
-        {
-            var options = new DbContextOptionsBuilder<DiaryDatabaseContext>()
-                .UseInMemoryDatabase(databaseName: "InMemoryDatabase")
-                .EnableSensitiveDataLogging()
-                .Options;
-            return new DiaryDatabaseContext(options);
-        }
+        private Mock<IDiaryService> _diaryService = null!;
 
         [TestInitialize]
-        public void InitDb()
+        public void Init()
         {
-            var db = GetMemoryContext();
-            if (db.Database.IsInMemory())
-            {
-                db.Database.EnsureDeleted();
-            }
+            _diaryService = new Mock<IDiaryService>();
         }
 
         [TestMethod]
-        public void Insert()
+        public async Task Insert()
         {
             // Arrange
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
-            var controller = CreateController(diaryService);
+            _diaryService.Setup(x => x.CreateAsync(It.IsAny<DiaryDTO>()))
+                .ReturnsAsync((DiaryDTO d) =>
+                {
+                    d.DiaryId = Guid.NewGuid();
+                    return d;
+                });
+            var controller = CreateController();
 
             // Act
-            var response = controller.Create(new DiaryDTO { Author = "Paul", Title = "Paul's Diary" });
+            var response = await controller.Create(new DiaryDTO { Author = "Paul", Title = "Paul's Diary" });
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(CreatedResult));
@@ -62,18 +58,36 @@ namespace ccDiaryApiTest.v1
         }
 
         [TestMethod]
-        public void GetMany()
+        public async Task Create_StampsOwnerIdFromCallersOid()
         {
             // Arrange
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
-            var controller = CreateController(diaryService);
+            DiaryDTO? captured = null;
+            _diaryService.Setup(x => x.CreateAsync(It.IsAny<DiaryDTO>()))
+                .Callback<DiaryDTO>(d => captured = d)
+                .ReturnsAsync((DiaryDTO d) => d);
+            var controller = CreateController(oid: "owner-oid");
 
             // Act
-            controller.Create(new DiaryDTO { Author = "Paul1", Title = "Paul's 1st Diary" });
-            controller.Create(new DiaryDTO { Author = "Paul2", Title = "Paul's 2nd Diary" });
-            controller.Create(new DiaryDTO { Author = "Paul3", Title = "Paul's 3rd Diary" });
-            var response = controller.Get();
+            await controller.Create(new DiaryDTO { Author = "Paul", Title = "Paul's Diary" });
+
+            // Assert
+            Assert.IsNotNull(captured);
+            Assert.AreEqual("owner-oid", captured.OwnerId);
+        }
+
+        [TestMethod]
+        public async Task GetMany()
+        {
+            // Arrange
+            var page = NewPage(
+                new DiaryDTO { DiaryId = Guid.NewGuid(), Author = "Paul1", Title = "Paul's 1st Diary" },
+                new DiaryDTO { DiaryId = Guid.NewGuid(), Author = "Paul2", Title = "Paul's 2nd Diary" },
+                new DiaryDTO { DiaryId = Guid.NewGuid(), Author = "Paul3", Title = "Paul's 3rd Diary" });
+            _diaryService.Setup(x => x.GetDiariesAsync(1, 12, null)).ReturnsAsync(page);
+            var controller = CreateController();
+
+            // Act
+            var response = await controller.Get();
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
@@ -84,336 +98,271 @@ namespace ccDiaryApiTest.v1
         }
 
         [TestMethod]
-        public void GetSingle()
+        public async Task GetNone()
         {
             // Arrange
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
-            var controller = CreateController(diaryService);
+            _diaryService.Setup(x => x.GetDiariesAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>()))
+                .ReturnsAsync(NewPage());
+            var controller = CreateController();
 
             // Act
-            controller.Create(new DiaryDTO { Author = "Paul", Title = "Paul's Diary" });
-            var response = controller.Get();
+            var response = await controller.Get();
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
             var result = response.GetObjectResult();
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, result.TotalCount);
-            Assert.AreEqual(1, result.Items.Count());
-            Assert.AreEqual("Paul's Diary", result.Items.First().Title);
-            Assert.AreNotEqual(Guid.Empty, result.Items.First().DiaryId);
+            Assert.AreEqual(0, result.TotalCount);
+            Assert.AreEqual(0, result.Items.Count());
         }
 
         [TestMethod]
-        public void GetSingleById()
+        public async Task GetSingleById()
         {
             // Arrange
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
-            var controller = CreateController(diaryService);
+            var diaryId = Guid.NewGuid();
+            var diary = new DiaryDTO
+            {
+                DiaryId = diaryId,
+                Author = "Paul2",
+                Title = "Paul's 2nd Diary",
+                Description = "Description of Paul's 2nd Diary",
+            };
+            _diaryService.Setup(x => x.GetDiaryAsync(diaryId)).ReturnsAsync(diary);
+            var controller = CreateController();
 
             // Act
-            controller.Create(new DiaryDTO { Author = "Paul1", Title = "Paul's 1st Diary", Description = "Description of Paul's 1st Diary" });
-            var createResponse = controller.Create(new DiaryDTO { Author = "Paul2", Title = "Paul's 2nd Diary", Description = "Description of Paul's 2nd Diary" });
-            controller.Create(new DiaryDTO { Author = "Paul3", Title = "Paul's 3rd Diary", Description = "Description of Paul's 3rd Diary" });
-            var createResult = createResponse.GetObjectResult();
-            Assert.IsNotNull(createResult);
-            var response = controller.Get(createResult.DiaryId!.Value);
+            var response = await controller.Get(diaryId);
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
             var result = response.GetObjectResult();
             Assert.IsNotNull(result);
-            Assert.AreEqual(createResult.DiaryId, result.DiaryId);
+            Assert.AreEqual(diaryId, result.DiaryId);
             Assert.AreEqual("Paul2", result.Author);
             Assert.AreEqual("Paul's 2nd Diary", result.Title);
             Assert.AreEqual("Description of Paul's 2nd Diary", result.Description);
         }
 
         [TestMethod]
-        public void Delete()
+        public async Task Get_PassesSearchTermThrough()
         {
             // Arrange
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
-            var controller = CreateController(diaryService);
-
-            controller.Create(new DiaryDTO { Author = "Paul1", Title = "Paul's 1st Diary", Description = "Description of Paul's 1st Diary" });
-            var createResponse = controller.Create(new DiaryDTO { Author = "Paul2", Title = "Paul's 2nd Diary", Description = "Description of Paul's 2nd Diary" });
-            controller.Create(new DiaryDTO { Author = "Paul3", Title = "Paul's 3rd Diary", Description = "Description of Paul's 3rd Diary" });
-            var createResult = createResponse.GetObjectResult();
-            Assert.IsNotNull(createResult);
-            var preGetResponse = controller.Get();
-            var preGetResult = preGetResponse.GetObjectResult();
-            Assert.IsNotNull(preGetResult);
-            Assert.AreEqual(3, preGetResult.TotalCount);
+            _diaryService.Setup(x => x.GetDiariesAsync(1, 12, "World War")).ReturnsAsync(NewPage());
+            var controller = CreateController();
 
             // Act
-            var response = controller.Delete(createResult.DiaryId!.Value);
+            await controller.Get(search: "World War");
 
             // Assert
-            Assert.IsInstanceOfType(response, typeof(OkResult));
-            var postGetResponse = controller.Get();
-            var postGetResult = postGetResponse.GetObjectResult();
-            Assert.IsNotNull(postGetResult);
-            Assert.AreEqual(2, postGetResult.TotalCount);
+            _diaryService.Verify(x => x.GetDiariesAsync(1, 12, "World War"), Times.Once);
         }
 
         [TestMethod]
-        public void DeleteNone()
+        public async Task Get_ClampsPageSizeToMaximum()
         {
             // Arrange
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
-            var controller = CreateController(diaryService);
+            _diaryService.Setup(x => x.GetDiariesAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>()))
+                .ReturnsAsync(NewPage());
+            var controller = CreateController();
 
             // Act
-            var response = controller.Delete(Guid.NewGuid());
+            await controller.Get(page: 1, pageSize: 5000);
 
             // Assert
-            Assert.IsInstanceOfType(response, typeof(NotFoundResult));
+            _diaryService.Verify(x => x.GetDiariesAsync(1, PagingLimits.MaxPageSize, null), Times.Once);
         }
 
         [TestMethod]
-        public void Update()
+        public async Task Get_ClampsNonPositivePageAndPageSize()
         {
             // Arrange
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
-            var controller = CreateController(diaryService);
-
-            var createResponse = controller.Create(new DiaryDTO { Author = "Paul2", Title = "Paul's 2nd Diary", Description = "Description of Paul's 2nd Diary" });
-            var createResult = createResponse.GetObjectResult();
-            Assert.IsNotNull(createResult);
+            _diaryService.Setup(x => x.GetDiariesAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string?>()))
+                .ReturnsAsync(NewPage());
+            var controller = CreateController();
 
             // Act
-            createResult.Author = "John";
-            createResult.Title = "John's Diary";
-            createResult.Description = "Description of John's Diary";
-            var response = controller.Update(createResult);
+            await controller.Get(page: 0, pageSize: 0);
 
             // Assert
-            Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
-            var result = response.GetObjectResult();
-            Assert.IsNotNull(result);
-            Assert.AreEqual(createResult.DiaryId, result.DiaryId);
-            Assert.AreEqual("John", result.Author);
-            Assert.AreEqual("John's Diary", result.Title);
-            Assert.AreEqual("Description of John's Diary", result.Description);
+            _diaryService.Verify(x => x.GetDiariesAsync(1, 1, null), Times.Once);
         }
 
         [TestMethod]
-        public void GetNone()
+        public async Task GetPaged_PassesPagingThrough()
         {
             // Arrange
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
-            var controller = CreateController(diaryService);
+            var page = NewPage(new DiaryDTO { DiaryId = Guid.NewGuid(), Author = "Author01", Title = "Diary01" });
+            page.TotalCount = 15;
+            page.Page = 2;
+            page.PageSize = 5;
+            _diaryService.Setup(x => x.GetDiariesAsync(2, 5, null)).ReturnsAsync(page);
+            var controller = CreateController();
 
             // Act
-            var response = controller.Get();
-
-            // Assert
-            Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
-            var result = response.GetObjectResult();
-            Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.TotalCount);
-            Assert.AreEqual(0, result.Items.Count());
-        }
-
-        [TestMethod]
-        public void GetPaged_ReturnsCorrectPage()
-        {
-            // Arrange
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
-            var controller = CreateController(diaryService);
-
-            for (int i = 1; i <= 15; i++)
-            {
-                controller.Create(new DiaryDTO { Author = $"Author{i:D2}", Title = $"Diary{i:D2}" });
-            }
-
-            // Act — page 2 with page size 5
-            var response = controller.Get(page: 2, pageSize: 5);
+            var response = await controller.Get(page: 2, pageSize: 5);
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
             var result = response.GetObjectResult();
             Assert.IsNotNull(result);
             Assert.AreEqual(15, result.TotalCount);
-            Assert.AreEqual(5, result.Items.Count());
             Assert.AreEqual(2, result.Page);
             Assert.AreEqual(5, result.PageSize);
         }
 
         [TestMethod]
-        public void Update_AsNonOwner_ReturnsForbid()
+        public async Task Delete()
         {
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
+            // Arrange
+            var diaryId = Guid.NewGuid();
+            var diary = new DiaryDTO { DiaryId = diaryId, Author = "Paul", Title = "Paul's Diary", OwnerId = "owner-oid" };
+            _diaryService.Setup(x => x.GetDiaryAsync(diaryId)).ReturnsAsync(diary);
+            var controller = CreateController(oid: "owner-oid");
 
-            var ownerController = CreateController(diaryService, oid: "owner-oid");
-            var diary = ownerController.Create(new DiaryDTO { Author = "Owner", Title = "Owner's Diary" }).GetObjectResult();
-            Assert.IsNotNull(diary);
+            // Act
+            var response = await controller.Delete(diaryId);
 
-            var otherController = CreateController(diaryService, oid: "other-oid");
-            diary.Title = "Hijacked";
-            var response = otherController.Update(diary);
-
-            Assert.IsInstanceOfType(response.Result, typeof(ForbidResult));
-        }
-
-        [TestMethod]
-        public void Update_WithMissingDiary_ReturnsForbid()
-        {
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
-            var controller = CreateController(diaryService, oid: "user-oid");
-
-            var response = controller.Update(new DiaryDTO { DiaryId = Guid.NewGuid(), Author = "Ghost", Title = "Ghost Diary" });
-
-            Assert.IsInstanceOfType(response.Result, typeof(ForbidResult));
-        }
-
-        [TestMethod]
-        public void Update_AsAdmin_ReturnsOk()
-        {
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
-
-            var ownerController = CreateController(diaryService, oid: "owner-oid");
-            var diary = ownerController.Create(new DiaryDTO { Author = "Owner", Title = "Owner's Diary" }).GetObjectResult();
-            Assert.IsNotNull(diary);
-
-            var adminController = CreateController(diaryService, oid: "admin-oid", isAdmin: true);
-            diary.Title = "Admin Updated";
-            var response = adminController.Update(diary);
-
-            Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
-        }
-
-        [TestMethod]
-        public void Delete_AsNonOwner_ReturnsForbid()
-        {
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
-
-            var ownerController = CreateController(diaryService, oid: "owner-oid");
-            var diary = ownerController.Create(new DiaryDTO { Author = "Owner", Title = "Owner's Diary" }).GetObjectResult();
-            Assert.IsNotNull(diary);
-
-            var otherController = CreateController(diaryService, oid: "other-oid");
-            var response = otherController.Delete(diary.DiaryId!.Value);
-
-            Assert.IsInstanceOfType(response, typeof(ForbidResult));
-        }
-
-        [TestMethod]
-        public void Delete_AsAdmin_ReturnsOk()
-        {
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
-
-            var ownerController = CreateController(diaryService, oid: "owner-oid");
-            var diary = ownerController.Create(new DiaryDTO { Author = "Owner", Title = "Owner's Diary" }).GetObjectResult();
-            Assert.IsNotNull(diary);
-
-            var adminController = CreateController(diaryService, oid: "admin-oid", isAdmin: true);
-            var response = adminController.Delete(diary.DiaryId!.Value);
-
+            // Assert
             Assert.IsInstanceOfType(response, typeof(OkResult));
+            _diaryService.Verify(x => x.DeleteAsync(diary), Times.Once);
         }
 
         [TestMethod]
-        public void GetSearch_ByTitle_ReturnsFilteredResults()
+        public async Task DeleteNone()
         {
             // Arrange
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
-            var controller = CreateController(diaryService);
-
-            controller.Create(new DiaryDTO { Author = "AuthorA", Title = "World War One" });
-            controller.Create(new DiaryDTO { Author = "AuthorB", Title = "World War Two" });
-            controller.Create(new DiaryDTO { Author = "AuthorC", Title = "Cold War Stories" });
+            _diaryService.Setup(x => x.GetDiaryAsync(It.IsAny<Guid>())).ReturnsAsync((DiaryDTO?)null);
+            var controller = CreateController();
 
             // Act
-            var response = controller.Get(search: "World War");
+            var response = await controller.Delete(Guid.NewGuid());
+
+            // Assert
+            Assert.IsInstanceOfType(response, typeof(NotFoundResult));
+            _diaryService.Verify(x => x.DeleteAsync(It.IsAny<DiaryDTO>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task Update()
+        {
+            // Arrange
+            var diaryId = Guid.NewGuid();
+            var updated = new DiaryDTO
+            {
+                DiaryId = diaryId,
+                Author = "John",
+                Title = "John's Diary",
+                Description = "Description of John's Diary",
+                OwnerId = "owner-oid",
+            };
+            _diaryService.Setup(x => x.GetDiaryAsync(diaryId)).ReturnsAsync(updated);
+            _diaryService.Setup(x => x.UpdateAsync(It.IsAny<DiaryDTO>())).ReturnsAsync((DiaryDTO d) => d);
+            var controller = CreateController(oid: "owner-oid");
+
+            // Act
+            var response = await controller.Update(updated);
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
             var result = response.GetObjectResult();
             Assert.IsNotNull(result);
-            Assert.AreEqual(2, result.TotalCount);
-            Assert.AreEqual(2, result.Items.Count());
+            Assert.AreEqual(diaryId, result.DiaryId);
+            Assert.AreEqual("John", result.Author);
+            Assert.AreEqual("John's Diary", result.Title);
+            Assert.AreEqual("Description of John's Diary", result.Description);
         }
 
         [TestMethod]
-        public void GetSearch_ByDescription_ReturnsFilteredResults()
+        public async Task Update_AsNonOwner_ReturnsForbid()
         {
             // Arrange
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
-            var controller = CreateController(diaryService);
-
-            controller.Create(new DiaryDTO { Author = "AuthorA", Title = "Diary One", Description = "Trench warfare in France" });
-            controller.Create(new DiaryDTO { Author = "AuthorB", Title = "Diary Two", Description = "Naval battles in the Pacific" });
+            var diaryId = Guid.NewGuid();
+            var diary = new DiaryDTO { DiaryId = diaryId, Author = "Owner", Title = "Owner's Diary", OwnerId = "owner-oid" };
+            _diaryService.Setup(x => x.GetDiaryAsync(diaryId)).ReturnsAsync(diary);
+            var controller = CreateController(oid: "other-oid");
 
             // Act
-            var response = controller.Get(search: "France");
+            var response = await controller.Update(new DiaryDTO { DiaryId = diaryId, Author = "Owner", Title = "Hijacked" });
 
             // Assert
-            Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
-            var result = response.GetObjectResult();
-            Assert.IsNotNull(result);
-            Assert.AreEqual(1, result.TotalCount);
-            Assert.AreEqual("Diary One", result.Items.First().Title);
+            Assert.IsInstanceOfType(response.Result, typeof(ForbidResult));
+            _diaryService.Verify(x => x.UpdateAsync(It.IsAny<DiaryDTO>()), Times.Never);
         }
 
         [TestMethod]
-        public void GetSearch_NoMatch_ReturnsEmpty()
+        public async Task Update_WithMissingDiary_ReturnsForbid()
         {
             // Arrange
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
-            var controller = CreateController(diaryService);
-
-            controller.Create(new DiaryDTO { Author = "AuthorA", Title = "War Diary", Description = "Some description" });
+            _diaryService.Setup(x => x.GetDiaryAsync(It.IsAny<Guid>())).ReturnsAsync((DiaryDTO?)null);
+            var controller = CreateController(oid: "user-oid");
 
             // Act
-            var response = controller.Get(search: "zzznomatch");
+            var response = await controller.Update(new DiaryDTO { DiaryId = Guid.NewGuid(), Author = "Ghost", Title = "Ghost Diary" });
 
             // Assert
-            Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
-            var result = response.GetObjectResult();
-            Assert.IsNotNull(result);
-            Assert.AreEqual(0, result.TotalCount);
-            Assert.AreEqual(0, result.Items.Count());
+            Assert.IsInstanceOfType(response.Result, typeof(ForbidResult));
         }
 
         [TestMethod]
-        public void GetSearch_EmptySearch_ReturnsAll()
+        public async Task Update_AsAdmin_ReturnsOk()
         {
-            // Arrange
-            var db = GetMemoryContext();
-            var diaryService = new DiaryService(db);
-            var controller = CreateController(diaryService);
-
-            controller.Create(new DiaryDTO { Author = "AuthorA", Title = "Diary One" });
-            controller.Create(new DiaryDTO { Author = "AuthorB", Title = "Diary Two" });
+            // Arrange — an admin never triggers the ownership lookup
+            var diary = new DiaryDTO { DiaryId = Guid.NewGuid(), Author = "Owner", Title = "Admin Updated", OwnerId = "owner-oid" };
+            _diaryService.Setup(x => x.UpdateAsync(It.IsAny<DiaryDTO>())).ReturnsAsync((DiaryDTO d) => d);
+            var controller = CreateController(oid: "admin-oid", isAdmin: true);
 
             // Act
-            var response = controller.Get(search: string.Empty);
+            var response = await controller.Update(diary);
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
-            var result = response.GetObjectResult();
-            Assert.IsNotNull(result);
-            Assert.AreEqual(2, result.TotalCount);
+            _diaryService.Verify(x => x.GetDiaryAsync(It.IsAny<Guid>()), Times.Never);
         }
 
-        private static DiaryController CreateController(IDiaryService service, string? oid = null, bool isAdmin = false)
+        [TestMethod]
+        public async Task Delete_AsNonOwner_ReturnsForbid()
+        {
+            // Arrange
+            var diaryId = Guid.NewGuid();
+            var diary = new DiaryDTO { DiaryId = diaryId, Author = "Owner", Title = "Owner's Diary", OwnerId = "owner-oid" };
+            _diaryService.Setup(x => x.GetDiaryAsync(diaryId)).ReturnsAsync(diary);
+            var controller = CreateController(oid: "other-oid");
+
+            // Act
+            var response = await controller.Delete(diaryId);
+
+            // Assert
+            Assert.IsInstanceOfType(response, typeof(ForbidResult));
+            _diaryService.Verify(x => x.DeleteAsync(It.IsAny<DiaryDTO>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task Delete_AsAdmin_ReturnsOk()
+        {
+            // Arrange
+            var diaryId = Guid.NewGuid();
+            var diary = new DiaryDTO { DiaryId = diaryId, Author = "Owner", Title = "Owner's Diary", OwnerId = "owner-oid" };
+            _diaryService.Setup(x => x.GetDiaryAsync(diaryId)).ReturnsAsync(diary);
+            var controller = CreateController(oid: "admin-oid", isAdmin: true);
+
+            // Act
+            var response = await controller.Delete(diaryId);
+
+            // Assert
+            Assert.IsInstanceOfType(response, typeof(OkResult));
+            _diaryService.Verify(x => x.DeleteAsync(diary), Times.Once);
+        }
+
+        private static PagedResultDTO<DiaryDTO> NewPage(params DiaryDTO[] items) => new ()
+        {
+            Items = items.ToList(),
+            TotalCount = items.Length,
+            Page = 1,
+            PageSize = 12,
+        };
+
+        private DiaryController CreateController(string? oid = null, bool isAdmin = false)
         {
             var claims = new List<Claim>();
             if (oid != null)
@@ -426,15 +375,16 @@ namespace ccDiaryApiTest.v1
                 claims.Add(new Claim(ClaimTypes.Role, "DiaryAdmin"));
             }
 
-            var controller = new DiaryController(service);
-            controller.ControllerContext = new ControllerContext
+            return new DiaryController(_diaryService.Object)
             {
-                HttpContext = new DefaultHttpContext
+                ControllerContext = new ControllerContext
                 {
-                    User = new ClaimsPrincipal(new ClaimsIdentity(claims, claims.Count > 0 ? "Test" : string.Empty)),
+                    HttpContext = new DefaultHttpContext
+                    {
+                        User = new ClaimsPrincipal(new ClaimsIdentity(claims, claims.Count > 0 ? "Test" : string.Empty)),
+                    },
                 },
             };
-            return controller;
         }
     }
 }

--- a/src/api/ccDiaryApiTest/v1/DiaryEntryControllerTest.cs
+++ b/src/api/ccDiaryApiTest/v1/DiaryEntryControllerTest.cs
@@ -18,19 +18,19 @@ namespace ccDiaryApiTest.v1
     public class DiaryEntryControllerTest
     {
         [TestMethod]
-        public void GetValid()
+        public async Task GetValid()
         {
             // Arrange
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
 
             Guid id = Guid.NewGuid();
             var diaryEntry = new DiaryEntryDTO { DiaryEntryId = id, DiaryId = Guid.NewGuid(), Date = DateTime.UtcNow, Location = "London", Entry = "Some text." };
-            diaryEntryServiceMock.Setup(x => x.GetDiaryEntry(id)).Returns(diaryEntry);
+            diaryEntryServiceMock.Setup(x => x.GetDiaryEntryAsync(id)).ReturnsAsync(diaryEntry);
             var diaryServiceMock = new Mock<IDiaryService>();
             var controller = new DiaryEntryController(diaryEntryServiceMock.Object, diaryServiceMock.Object);
 
             // Act
-            var response = controller.Get(id);
+            var response = await controller.Get(id);
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
@@ -40,7 +40,7 @@ namespace ccDiaryApiTest.v1
         }
 
         [TestMethod]
-        public void GetInvalid()
+        public async Task GetInvalid()
         {
             // Arrange
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
@@ -48,7 +48,7 @@ namespace ccDiaryApiTest.v1
             var controller = new DiaryEntryController(diaryEntryServiceMock.Object, diaryServiceMock.Object);
 
             // Act
-            var response = controller.Get(Guid.NewGuid());
+            var response = await controller.Get(Guid.NewGuid());
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(NotFoundResult));
@@ -56,7 +56,7 @@ namespace ccDiaryApiTest.v1
         }
 
         [TestMethod]
-        public void SearchByDiaryId()
+        public async Task SearchByDiaryId()
         {
             // Arrange
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
@@ -65,9 +65,9 @@ namespace ccDiaryApiTest.v1
             var from = DateTime.UtcNow;
             var to = DateTime.UtcNow;
             var searchType = SearchType.Day;
-            diaryEntryServiceMock.Setup(h => h.GetDiaryDateRange(It.IsAny<Guid>()))
-                .Returns(new DiaryDateRange { MaxDateTime = DateTime.MaxValue, MinDateTime = DateTime.MinValue });
-            diaryEntryServiceMock.Setup(h => h.SearchDiaryEntries(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<SearchType>(), It.IsAny<int>()))
+            diaryEntryServiceMock.Setup(h => h.GetDiaryDateRangeAsync(It.IsAny<Guid>()))
+                .ReturnsAsync(new DiaryDateRange { MaxDateTime = DateTime.MaxValue, MinDateTime = DateTime.MinValue });
+            diaryEntryServiceMock.Setup(h => h.SearchDiaryEntriesAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<SearchType>(), It.IsAny<int>()))
                 .Callback<Guid, DateTime, DateTime, SearchType, int>((d, f, t, s, o) =>
                 {
                     diaryId = d;
@@ -75,14 +75,14 @@ namespace ccDiaryApiTest.v1
                     to = t;
                     searchType = s;
                 })
-                .Returns([2022, 2023]);
+                .ReturnsAsync(new List<int> { 2022, 2023 });
 
             var diaryServiceMock = new Mock<IDiaryService>();
             var controller = new DiaryEntryController(diaryEntryServiceMock.Object, diaryServiceMock.Object);
 
             // Act
             var id = Guid.NewGuid();
-            var response = controller.Search(id);
+            var response = await controller.Search(id);
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
@@ -95,7 +95,7 @@ namespace ccDiaryApiTest.v1
         }
 
         [TestMethod]
-        public void SearchByYear()
+        public async Task SearchByYear()
         {
             // Arrange
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
@@ -104,7 +104,7 @@ namespace ccDiaryApiTest.v1
             var from = DateTime.UtcNow;
             var to = DateTime.UtcNow;
             var searchType = SearchType.Day;
-            diaryEntryServiceMock.Setup(h => h.SearchDiaryEntries(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<SearchType>(), It.IsAny<int>()))
+            diaryEntryServiceMock.Setup(h => h.SearchDiaryEntriesAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<SearchType>(), It.IsAny<int>()))
                 .Callback<Guid, DateTime, DateTime, SearchType, int>((d, f, t, s, o) =>
                 {
                     diaryId = d;
@@ -112,14 +112,14 @@ namespace ccDiaryApiTest.v1
                     to = t;
                     searchType = s;
                 })
-                .Returns([04, 05, 08]);
+                .ReturnsAsync(new List<int> { 04, 05, 08 });
 
             var diaryServiceMock = new Mock<IDiaryService>();
             var controller = new DiaryEntryController(diaryEntryServiceMock.Object, diaryServiceMock.Object);
 
             // Act
             var id = Guid.NewGuid();
-            var response = controller.Search(id, 2022);
+            var response = await controller.Search(id, 2022);
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
@@ -132,7 +132,7 @@ namespace ccDiaryApiTest.v1
         }
 
         [TestMethod]
-        public void SearchByYearAndMonth()
+        public async Task SearchByYearAndMonth()
         {
             // Arrange
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
@@ -141,7 +141,7 @@ namespace ccDiaryApiTest.v1
             var from = DateTime.UtcNow;
             var to = DateTime.UtcNow;
             var searchType = SearchType.Day;
-            diaryEntryServiceMock.Setup(h => h.SearchDiaryEntries(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<SearchType>(), It.IsAny<int>()))
+            diaryEntryServiceMock.Setup(h => h.SearchDiaryEntriesAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<SearchType>(), It.IsAny<int>()))
                 .Callback<Guid, DateTime, DateTime, SearchType, int>((d, f, t, s, o) =>
                 {
                     diaryId = d;
@@ -149,14 +149,14 @@ namespace ccDiaryApiTest.v1
                     to = t;
                     searchType = s;
                 })
-                .Returns([7, 13, 23, 30]);
+                .ReturnsAsync(new List<int> { 7, 13, 23, 30 });
 
             var diaryServiceMock = new Mock<IDiaryService>();
             var controller = new DiaryEntryController(diaryEntryServiceMock.Object, diaryServiceMock.Object);
 
             // Act
             var id = Guid.NewGuid();
-            var response = controller.Search(id, 2022, 5, 0);
+            var response = await controller.Search(id, 2022, 5, 0);
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
@@ -169,7 +169,7 @@ namespace ccDiaryApiTest.v1
         }
 
         [TestMethod]
-        public void SearchByYearAndMonthWithUTCOffset()
+        public async Task SearchByYearAndMonthWithUTCOffset()
         {
             // Arrange
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
@@ -177,21 +177,21 @@ namespace ccDiaryApiTest.v1
             var from = DateTime.UtcNow;
             var to = DateTime.UtcNow;
             var capturedOffset = -1;
-            diaryEntryServiceMock.Setup(h => h.SearchDiaryEntries(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<SearchType>(), It.IsAny<int>()))
+            diaryEntryServiceMock.Setup(h => h.SearchDiaryEntriesAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<SearchType>(), It.IsAny<int>()))
                 .Callback<Guid, DateTime, DateTime, SearchType, int>((d, f, t, s, o) =>
                 {
                     from = f;
                     to = t;
                     capturedOffset = o;
                 })
-                .Returns([7, 13, 23, 24]);
+                .ReturnsAsync(new List<int> { 7, 13, 23, 24 });
 
             var diaryServiceMock = new Mock<IDiaryService>();
             var controller = new DiaryEntryController(diaryEntryServiceMock.Object, diaryServiceMock.Object);
 
             // Act — BST offset (+60 min): local May starts at UTC April 30 23:00
             var id = Guid.NewGuid();
-            var response = controller.Search(id, 2022, 5, 60);
+            var response = await controller.Search(id, 2022, 5, 60);
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
@@ -201,7 +201,7 @@ namespace ccDiaryApiTest.v1
         }
 
         [TestMethod]
-        public void SearchByYearAndMonthAndDate()
+        public async Task SearchByYearAndMonthAndDate()
         {
             // Arrange
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
@@ -217,21 +217,21 @@ namespace ccDiaryApiTest.v1
                 Entry = "Test entry",
                 Location = "Test location",
             };
-            diaryEntryServiceMock.Setup(h => h.GetDiaryEntries(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            diaryEntryServiceMock.Setup(h => h.GetDiaryEntriesAsync(It.IsAny<Guid>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
                 .Callback<Guid, DateTime, DateTime>((d, f, t) =>
                 {
                     diaryId = d;
                     from = f;
                     to = t;
                 })
-                .Returns([diaryEntry]);
+                .ReturnsAsync(new List<DiaryEntryDTO> { diaryEntry });
 
             var diaryServiceMock = new Mock<IDiaryService>();
             var controller = new DiaryEntryController(diaryEntryServiceMock.Object, diaryServiceMock.Object);
 
             // Act
             var id = Guid.NewGuid();
-            var response = controller.Search(id, 2022, 5, 23, 0);
+            var response = await controller.Search(id, 2022, 5, 23, 0);
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
@@ -243,7 +243,7 @@ namespace ccDiaryApiTest.v1
         }
 
         [TestMethod]
-        public void CreatePassesThroughShowJourneyFields()
+        public async Task CreatePassesThroughShowJourneyFields()
         {
             // Arrange
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
@@ -261,17 +261,17 @@ namespace ccDiaryApiTest.v1
                 ToLocation = "Southampton, UK",
             };
             diaryEntryServiceMock
-                .Setup(x => x.CreateDiaryEntry(It.IsAny<DiaryEntryDTO>()))
+                .Setup(x => x.CreateDiaryEntryAsync(It.IsAny<DiaryEntryDTO>()))
                 .Callback<DiaryEntryDTO>(d => captured = d)
-                .Returns(diaryEntry);
+                .ReturnsAsync(diaryEntry);
 
             var diaryServiceMock = new Mock<IDiaryService>();
-            diaryServiceMock.Setup(x => x.GetDiary(It.IsAny<Guid>()))
-                .Returns(new DiaryDTO { DiaryId = diaryEntry.DiaryId, Title = "Test", Author = "Test", OwnerId = null });
+            diaryServiceMock.Setup(x => x.GetDiaryAsync(It.IsAny<Guid>()))
+                .ReturnsAsync(new DiaryDTO { DiaryId = diaryEntry.DiaryId, Title = "Test", Author = "Test", OwnerId = null });
             var controller = CreateController(diaryEntryServiceMock.Object, diaryServiceMock.Object);
 
             // Act
-            var response = controller.Create(diaryEntry);
+            var response = await controller.Create(diaryEntry);
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(CreatedResult));
@@ -282,7 +282,7 @@ namespace ccDiaryApiTest.v1
         }
 
         [TestMethod]
-        public void UpdatePassesThroughShowJourneyFields()
+        public async Task UpdatePassesThroughShowJourneyFields()
         {
             // Arrange
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
@@ -300,17 +300,17 @@ namespace ccDiaryApiTest.v1
                 ToLocation = "Paris, France",
             };
             diaryEntryServiceMock
-                .Setup(x => x.UpdateDiaryEntry(It.IsAny<DiaryEntryDTO>()))
+                .Setup(x => x.UpdateDiaryEntryAsync(It.IsAny<DiaryEntryDTO>()))
                 .Callback<DiaryEntryDTO>(d => captured = d)
-                .Returns(diaryEntry);
+                .ReturnsAsync(diaryEntry);
 
             var diaryServiceMock = new Mock<IDiaryService>();
-            diaryServiceMock.Setup(x => x.GetDiary(It.IsAny<Guid>()))
-                .Returns(new DiaryDTO { DiaryId = diaryEntry.DiaryId, Title = "Test", Author = "Test", OwnerId = null });
+            diaryServiceMock.Setup(x => x.GetDiaryAsync(It.IsAny<Guid>()))
+                .ReturnsAsync(new DiaryDTO { DiaryId = diaryEntry.DiaryId, Title = "Test", Author = "Test", OwnerId = null });
             var controller = CreateController(diaryEntryServiceMock.Object, diaryServiceMock.Object);
 
             // Act
-            var response = controller.Update(diaryEntry);
+            var response = await controller.Update(diaryEntry);
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
@@ -321,123 +321,123 @@ namespace ccDiaryApiTest.v1
         }
 
         [TestMethod]
-        public void Create_AsNonOwner_ReturnsForbid()
+        public async Task Create_AsNonOwner_ReturnsForbid()
         {
             var diaryEntry = new DiaryEntryDTO { DiaryEntryId = Guid.NewGuid(), DiaryId = Guid.NewGuid(), Date = DateTime.UtcNow, Location = "L", Entry = "E" };
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
             var diaryServiceMock = new Mock<IDiaryService>();
-            diaryServiceMock.Setup(x => x.GetDiary(It.IsAny<Guid>()))
-                .Returns(new DiaryDTO { Title = "T", Author = "A", OwnerId = "owner-oid" });
+            diaryServiceMock.Setup(x => x.GetDiaryAsync(It.IsAny<Guid>()))
+                .ReturnsAsync(new DiaryDTO { Title = "T", Author = "A", OwnerId = "owner-oid" });
 
             var controller = CreateController(diaryEntryServiceMock.Object, diaryServiceMock.Object, oid: "other-oid");
-            var response = controller.Create(diaryEntry);
+            var response = await controller.Create(diaryEntry);
 
             Assert.IsInstanceOfType(response.Result, typeof(ForbidResult));
         }
 
         [TestMethod]
-        public void Create_AsAdmin_ReturnsCreated()
+        public async Task Create_AsAdmin_ReturnsCreated()
         {
             var diaryEntry = new DiaryEntryDTO { DiaryEntryId = Guid.NewGuid(), DiaryId = Guid.NewGuid(), Date = DateTime.UtcNow, Location = "L", Entry = "E" };
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
-            diaryEntryServiceMock.Setup(x => x.CreateDiaryEntry(It.IsAny<DiaryEntryDTO>())).Returns(diaryEntry);
+            diaryEntryServiceMock.Setup(x => x.CreateDiaryEntryAsync(It.IsAny<DiaryEntryDTO>())).ReturnsAsync(diaryEntry);
             var diaryServiceMock = new Mock<IDiaryService>();
 
             var controller = CreateController(diaryEntryServiceMock.Object, diaryServiceMock.Object, oid: "admin-oid", isAdmin: true);
-            var response = controller.Create(diaryEntry);
+            var response = await controller.Create(diaryEntry);
 
             Assert.IsInstanceOfType(response.Result, typeof(CreatedResult));
         }
 
         [TestMethod]
-        public void Update_AsNonOwner_ReturnsForbid()
+        public async Task Update_AsNonOwner_ReturnsForbid()
         {
             var diaryEntry = new DiaryEntryDTO { DiaryEntryId = Guid.NewGuid(), DiaryId = Guid.NewGuid(), Date = DateTime.UtcNow, Location = "L", Entry = "E" };
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
             var diaryServiceMock = new Mock<IDiaryService>();
-            diaryServiceMock.Setup(x => x.GetDiary(It.IsAny<Guid>()))
-                .Returns(new DiaryDTO { Title = "T", Author = "A", OwnerId = "owner-oid" });
+            diaryServiceMock.Setup(x => x.GetDiaryAsync(It.IsAny<Guid>()))
+                .ReturnsAsync(new DiaryDTO { Title = "T", Author = "A", OwnerId = "owner-oid" });
 
             var controller = CreateController(diaryEntryServiceMock.Object, diaryServiceMock.Object, oid: "other-oid");
-            var response = controller.Update(diaryEntry);
+            var response = await controller.Update(diaryEntry);
 
             Assert.IsInstanceOfType(response.Result, typeof(ForbidResult));
         }
 
         [TestMethod]
-        public void Update_AsAdmin_ReturnsOk()
+        public async Task Update_AsAdmin_ReturnsOk()
         {
             var diaryEntry = new DiaryEntryDTO { DiaryEntryId = Guid.NewGuid(), DiaryId = Guid.NewGuid(), Date = DateTime.UtcNow, Location = "L", Entry = "E" };
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
-            diaryEntryServiceMock.Setup(x => x.UpdateDiaryEntry(It.IsAny<DiaryEntryDTO>())).Returns(diaryEntry);
+            diaryEntryServiceMock.Setup(x => x.UpdateDiaryEntryAsync(It.IsAny<DiaryEntryDTO>())).ReturnsAsync(diaryEntry);
             var diaryServiceMock = new Mock<IDiaryService>();
 
             var controller = CreateController(diaryEntryServiceMock.Object, diaryServiceMock.Object, oid: "admin-oid", isAdmin: true);
-            var response = controller.Update(diaryEntry);
+            var response = await controller.Update(diaryEntry);
 
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
         }
 
         [TestMethod]
-        public void Delete_EntryNotFound_ReturnsNotFound()
+        public async Task Delete_EntryNotFound_ReturnsNotFound()
         {
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
             var diaryServiceMock = new Mock<IDiaryService>();
             var controller = CreateController(diaryEntryServiceMock.Object, diaryServiceMock.Object);
 
-            var response = controller.Delete(Guid.NewGuid());
+            var response = await controller.Delete(Guid.NewGuid());
 
             Assert.IsInstanceOfType(response, typeof(NotFoundResult));
         }
 
         [TestMethod]
-        public void Delete_AsOwner_ReturnsOk()
+        public async Task Delete_AsOwner_ReturnsOk()
         {
             var diaryEntry = new DiaryEntryDTO { DiaryEntryId = Guid.NewGuid(), DiaryId = Guid.NewGuid(), Date = DateTime.UtcNow, Location = "L", Entry = "E" };
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
-            diaryEntryServiceMock.Setup(x => x.GetDiaryEntry(diaryEntry.DiaryEntryId!.Value)).Returns(diaryEntry);
+            diaryEntryServiceMock.Setup(x => x.GetDiaryEntryAsync(diaryEntry.DiaryEntryId!.Value)).ReturnsAsync(diaryEntry);
             var diaryServiceMock = new Mock<IDiaryService>();
-            diaryServiceMock.Setup(x => x.GetDiary(It.IsAny<Guid>()))
-                .Returns(new DiaryDTO { Title = "T", Author = "A", OwnerId = "owner-oid" });
+            diaryServiceMock.Setup(x => x.GetDiaryAsync(It.IsAny<Guid>()))
+                .ReturnsAsync(new DiaryDTO { Title = "T", Author = "A", OwnerId = "owner-oid" });
 
             var controller = CreateController(diaryEntryServiceMock.Object, diaryServiceMock.Object, oid: "owner-oid");
-            var response = controller.Delete(diaryEntry.DiaryEntryId!.Value);
+            var response = await controller.Delete(diaryEntry.DiaryEntryId!.Value);
 
             Assert.IsInstanceOfType(response, typeof(OkResult));
         }
 
         [TestMethod]
-        public void Delete_AsNonOwner_ReturnsForbid()
+        public async Task Delete_AsNonOwner_ReturnsForbid()
         {
             var diaryEntry = new DiaryEntryDTO { DiaryEntryId = Guid.NewGuid(), DiaryId = Guid.NewGuid(), Date = DateTime.UtcNow, Location = "L", Entry = "E" };
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
-            diaryEntryServiceMock.Setup(x => x.GetDiaryEntry(diaryEntry.DiaryEntryId!.Value)).Returns(diaryEntry);
+            diaryEntryServiceMock.Setup(x => x.GetDiaryEntryAsync(diaryEntry.DiaryEntryId!.Value)).ReturnsAsync(diaryEntry);
             var diaryServiceMock = new Mock<IDiaryService>();
-            diaryServiceMock.Setup(x => x.GetDiary(It.IsAny<Guid>()))
-                .Returns(new DiaryDTO { Title = "T", Author = "A", OwnerId = "owner-oid" });
+            diaryServiceMock.Setup(x => x.GetDiaryAsync(It.IsAny<Guid>()))
+                .ReturnsAsync(new DiaryDTO { Title = "T", Author = "A", OwnerId = "owner-oid" });
 
             var controller = CreateController(diaryEntryServiceMock.Object, diaryServiceMock.Object, oid: "other-oid");
-            var response = controller.Delete(diaryEntry.DiaryEntryId!.Value);
+            var response = await controller.Delete(diaryEntry.DiaryEntryId!.Value);
 
             Assert.IsInstanceOfType(response, typeof(ForbidResult));
         }
 
         [TestMethod]
-        public void Delete_AsAdmin_ReturnsOk()
+        public async Task Delete_AsAdmin_ReturnsOk()
         {
             var diaryEntry = new DiaryEntryDTO { DiaryEntryId = Guid.NewGuid(), DiaryId = Guid.NewGuid(), Date = DateTime.UtcNow, Location = "L", Entry = "E" };
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
-            diaryEntryServiceMock.Setup(x => x.GetDiaryEntry(diaryEntry.DiaryEntryId!.Value)).Returns(diaryEntry);
+            diaryEntryServiceMock.Setup(x => x.GetDiaryEntryAsync(diaryEntry.DiaryEntryId!.Value)).ReturnsAsync(diaryEntry);
             var diaryServiceMock = new Mock<IDiaryService>();
 
             var controller = CreateController(diaryEntryServiceMock.Object, diaryServiceMock.Object, oid: "admin-oid", isAdmin: true);
-            var response = controller.Delete(diaryEntry.DiaryEntryId!.Value);
+            var response = await controller.Delete(diaryEntry.DiaryEntryId!.Value);
 
             Assert.IsInstanceOfType(response, typeof(OkResult));
         }
 
         [TestMethod]
-        public void TextSearch_ReturnsMatchingEntries()
+        public async Task TextSearch_ReturnsMatchingEntries()
         {
             // Arrange
             var diaryId = Guid.NewGuid();
@@ -459,13 +459,13 @@ namespace ccDiaryApiTest.v1
 
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
             diaryEntryServiceMock
-                .Setup(x => x.TextSearchDiaryEntries(diaryId, "Menin", 1, 20))
-                .Returns(paged);
+                .Setup(x => x.TextSearchDiaryEntriesAsync(diaryId, "Menin", 1, 20))
+                .ReturnsAsync(paged);
             var diaryServiceMock = new Mock<IDiaryService>();
             var controller = new DiaryEntryController(diaryEntryServiceMock.Object, diaryServiceMock.Object);
 
             // Act
-            var response = controller.TextSearch(diaryId, "Menin");
+            var response = await controller.TextSearch(diaryId, "Menin");
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
@@ -476,7 +476,7 @@ namespace ccDiaryApiTest.v1
         }
 
         [TestMethod]
-        public void TextSearch_MatchesLocation()
+        public async Task TextSearch_MatchesLocation()
         {
             // Arrange
             var diaryId = Guid.NewGuid();
@@ -490,13 +490,13 @@ namespace ccDiaryApiTest.v1
 
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
             diaryEntryServiceMock
-                .Setup(x => x.TextSearchDiaryEntries(diaryId, "Passchendaele", 1, 20))
-                .Returns(paged);
+                .Setup(x => x.TextSearchDiaryEntriesAsync(diaryId, "Passchendaele", 1, 20))
+                .ReturnsAsync(paged);
             var diaryServiceMock = new Mock<IDiaryService>();
             var controller = new DiaryEntryController(diaryEntryServiceMock.Object, diaryServiceMock.Object);
 
             // Act
-            var response = controller.TextSearch(diaryId, "Passchendaele");
+            var response = await controller.TextSearch(diaryId, "Passchendaele");
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));
@@ -506,7 +506,7 @@ namespace ccDiaryApiTest.v1
         }
 
         [TestMethod]
-        public void TextSearch_EmptySearch_ReturnsBadRequest()
+        public async Task TextSearch_EmptySearch_ReturnsBadRequest()
         {
             // Arrange
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
@@ -514,14 +514,14 @@ namespace ccDiaryApiTest.v1
             var controller = new DiaryEntryController(diaryEntryServiceMock.Object, diaryServiceMock.Object);
 
             // Act
-            var response = controller.TextSearch(Guid.NewGuid(), "   ");
+            var response = await controller.TextSearch(Guid.NewGuid(), "   ");
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(BadRequestObjectResult));
         }
 
         [TestMethod]
-        public void TextSearch_NoMatch_ReturnsEmptyPage()
+        public async Task TextSearch_NoMatch_ReturnsEmptyPage()
         {
             // Arrange
             var diaryId = Guid.NewGuid();
@@ -535,13 +535,13 @@ namespace ccDiaryApiTest.v1
 
             var diaryEntryServiceMock = new Mock<IDiaryEntryService>();
             diaryEntryServiceMock
-                .Setup(x => x.TextSearchDiaryEntries(diaryId, "zzznomatch", 1, 20))
-                .Returns(emptyPaged);
+                .Setup(x => x.TextSearchDiaryEntriesAsync(diaryId, "zzznomatch", 1, 20))
+                .ReturnsAsync(emptyPaged);
             var diaryServiceMock = new Mock<IDiaryService>();
             var controller = new DiaryEntryController(diaryEntryServiceMock.Object, diaryServiceMock.Object);
 
             // Act
-            var response = controller.TextSearch(diaryId, "zzznomatch");
+            var response = await controller.TextSearch(diaryId, "zzznomatch");
 
             // Assert
             Assert.IsInstanceOfType(response.Result, typeof(OkObjectResult));

--- a/src/api/ccDiaryApiTest/v1/DiaryEntryServiceTest.cs
+++ b/src/api/ccDiaryApiTest/v1/DiaryEntryServiceTest.cs
@@ -13,63 +13,63 @@ namespace ccDiaryApiTest.v1
     public class DiaryEntryServiceTest
     {
         [TestMethod]
-        public void SearchDiaryEntries_ThrowsArgumentException_ForInvalidSearchType()
+        public async Task SearchDiaryEntries_ThrowsArgumentException_ForInvalidSearchType()
         {
             // Arrange
             var db = GetMemoryContext();
             var service = new DiaryEntryService(db);
 
             // Act & Assert
-            Assert.ThrowsException<ArgumentException>(() =>
+            await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
             {
-                service.SearchDiaryEntries(Guid.NewGuid(), DateTime.MinValue, DateTime.MaxValue, (SearchType)99);
+                await service.SearchDiaryEntriesAsync(Guid.NewGuid(), DateTime.MinValue, DateTime.MaxValue, (SearchType)99);
             });
         }
 
         [TestMethod]
-        public void CreateDiaryEntry_ThrowsArgumentException_WhenDateIsNull()
+        public async Task CreateDiaryEntry_ThrowsArgumentException_WhenDateIsNull()
         {
             var db = GetMemoryContext();
             var service = new DiaryEntryService(db);
 
-            Assert.ThrowsException<ArgumentException>(() =>
+            await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
             {
-                service.CreateDiaryEntry(new DiaryEntryDTO { DiaryId = Guid.NewGuid(), Entry = "E", Location = "L", Date = null });
+                await service.CreateDiaryEntryAsync(new DiaryEntryDTO { DiaryId = Guid.NewGuid(), Entry = "E", Location = "L", Date = null });
             });
         }
 
         [TestMethod]
-        public void CreateDiaryEntry_ThrowsArgumentException_WhenDateIsMinValue()
+        public async Task CreateDiaryEntry_ThrowsArgumentException_WhenDateIsMinValue()
         {
             var db = GetMemoryContext();
             var service = new DiaryEntryService(db);
 
-            Assert.ThrowsException<ArgumentException>(() =>
+            await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
             {
-                service.CreateDiaryEntry(new DiaryEntryDTO { DiaryId = Guid.NewGuid(), Entry = "E", Location = "L", Date = DateTime.MinValue });
+                await service.CreateDiaryEntryAsync(new DiaryEntryDTO { DiaryId = Guid.NewGuid(), Entry = "E", Location = "L", Date = DateTime.MinValue });
             });
         }
 
         [TestMethod]
-        public void MinDiaryEntryDate_ReturnsApproximatelyUtcNow_WhenNoDiaryEntries()
+        public async Task MinDiaryEntryDate_ReturnsApproximatelyUtcNow_WhenNoDiaryEntries()
         {
             var db = GetMemoryContext();
             var service = new DiaryEntryService(db);
             var before = DateTime.UtcNow;
 
-            var result = service.MinDiaryEntryDate(Guid.NewGuid());
+            var result = await service.MinDiaryEntryDateAsync(Guid.NewGuid());
 
             Assert.IsTrue(result >= before.AddSeconds(-1) && result <= DateTime.UtcNow.AddSeconds(1));
         }
 
         [TestMethod]
-        public void MaxDiaryEntryDate_ReturnsApproximatelyUtcNow_WhenNoDiaryEntries()
+        public async Task MaxDiaryEntryDate_ReturnsApproximatelyUtcNow_WhenNoDiaryEntries()
         {
             var db = GetMemoryContext();
             var service = new DiaryEntryService(db);
             var before = DateTime.UtcNow;
 
-            var result = service.MaxDiaryEntryDate(Guid.NewGuid());
+            var result = await service.MaxDiaryEntryDateAsync(Guid.NewGuid());
 
             Assert.IsTrue(result >= before.AddSeconds(-1) && result <= DateTime.UtcNow.AddSeconds(1));
         }


### PR DESCRIPTION
## Why

Preparation for moving persistence off EF Core / SQL Server onto Azure Table + Blob Storage (to remove the serverless SQL resume latency and the free-tier cost cliff). The Azure storage SDKs are async-only, and sync-over-async on a 0.25 vCPU / 0.5 GiB container invites threadpool starvation.

Doing the async conversion **first, while still on SQL**, keeps this large mechanical change reviewable on its own and independently shippable. No storage code is introduced here.

## What

**Async conversion.** `IDiaryService`, `IDiaryEntryService`, `IAppInfoService` and `IDiaryArchiveService` become async, along with their EF implementations and the four controllers. `IUserService`, `IAccessRequestService` and `IMapTileService` were already async and are untouched.

**Routes, verbs, status codes and response bodies are unchanged.**

**Two previously implicit limits made explicit:**

| Guard | Before | After |
|---|---|---|
| `pageSize` on paged endpoints | unbounded | capped at 100, floored at 1 |
| `page` | unbounded (`page=0` produced `OFFSET -12 ROWS`, a latent 500) | floored at 1 |
| Archive import body | implicit Kestrel 30 MB | explicit 32 MB |
| Entry create/update body | implicit Kestrel 30 MB | explicit 16 MB |

The largest real archive is ~25 MB and the largest real image ~3.3 MB base64, so both body limits clear the actual data with headroom while bounding memory on a 0.5 GiB container.

## Tests

Controller tests move off the EF InMemory provider to mocked service interfaces. `DiaryControllerTest` had been driving a live `DiaryService` over an in-memory database, so its search and paging assertions were really service tests in disguise — those semantics are already covered end to end by `DiaryIntegrationTest` over HTTP. `DiaryEntryControllerTest` was already Moq-based and needed only the renames.

Added explicit coverage for the new clamping and for `Create` stamping `OwnerId` from the caller's `oid`.

The **integration suite passes unchanged**, which is the evidence that the wire contract held.

```
Build succeeded.
Passed! - Failed: 0, Passed: 286, Skipped: 0, Total: 286
```

## Reviewer notes

- Behaviour change to be aware of: a caller passing `?pageSize=1000` now receives 100 rather than everything.
- `dotnet format` contradicts itself in this repo (SA1000 rewrites `new()` to `new ()`, then the WHITESPACE rule wants the space removed). This pre-exists on `main` — files untouched by this PR report the identical error — and CI does not gate on it. New code follows the existing convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbFW1ijTd7jn6GM7jtnhdh