### PR TITLE
fix: give the hidden image file input an accessible name

### DIFF
--- a/src/ui/src/components/DiaryEntryEditor.vue
+++ b/src/ui/src/components/DiaryEntryEditor.vue
@@ -184,9 +184,17 @@
             >
               Remove Image
             </v-btn>
+            <!--
+              Hidden and opened programmatically by the button above, so it never
+              receives focus in normal use. It still needs a name: assistive technology
+              can reach it directly, and an unlabelled file input announces as nothing
+              more useful than "button".
+            -->
             <input
+              id="diary-entry-image-input"
               ref="fileInputRef"
               accept="image/jpeg,image/png,image/gif,image/webp"
+              aria-label="Choose an image file for this diary entry"
               style="display: none"
               type="file"
               @change="handleFileSelect"


### PR DESCRIPTION
Closes a SonarCloud bug open since **2026-04-07**: `Web:InputWithoutLabelCheck` on `DiaryEntryEditor.vue` — the file input has no `id` and no associated label (accessibility, WCAG2-A).

## Why it went unnoticed

The input is `display: none` and opened programmatically by the "Add Image" button, so it never receives focus in normal use. Assistive technology can still reach it directly, where an unlabelled file input announces as little more than "button" — leaving no way to tell what choosing a file would do.

## The fix

An `id` and an `aria-label`. A visible label would be wrong here: the control is deliberately hidden behind the button, so the label belongs on the control rather than in the layout.

## Scope

Unrelated to the storage migration and **not blocking it** — the UI quality gate on #118 was already green (`new_reliability_rating: 1`). Kept on its own branch so it merges independently.

Lint clean, typecheck clean, 150 UI component tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbFW1ijTd7jn6GM7jtnhdh