### PR TITLE
chore: ignore Vite's temporary transpiled config files

### DIFF
--- a/src/ui/.gitignore
+++ b/src/ui/.gitignore
@@ -23,3 +23,8 @@ pnpm-debug.log*
 
 # TypeScript incremental build cache
 *.tsbuildinfo
+
+# Vite writes a temporary bundled copy of the config next to it whenever the config
+# needs transpiling, and does not always clean it up — so these accumulate untracked
+# and clutter git status.
+vite.config.*.timestamp-*


### PR DESCRIPTION
Vite writes a bundled copy of the config next to it whenever the config needs transpiling, and does not reliably clean it up. Those files accumulate untracked and sit permanently in `git status` — one had been there through this entire session.

```
src/ui/vite.config.mts.timestamp-1779719580855-5ab6fd2a2a56d.mjs
```

One `.gitignore` line, plus a comment explaining why the pattern exists.

## Also worth knowing

While looking into this I checked whether build artifacts were tracked in the repository. **They are not** — 321 tracked files, none under `TestResults/`, `bin/`, `obj/` or `node_modules/`. `src/api/.gitignore:45` has covered `TestResults/` all along. I had earlier claimed otherwise; that was wrong, and this is the only genuine gap.

Separately I removed 18 MB of stale ignored artifacts from the working directory (`TestResults/` going back to April). That is local cleanup only — nothing in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbFW1ijTd7jn6GM7jtnhdh