### PR TITLE
fix: make the migration verifier detect rows the source does not have

### DIFF
--- a/src/api/ccDiary.Migrate/Verifier.cs
+++ b/src/api/ccDiary.Migrate/Verifier.cs
@@ -46,6 +46,20 @@ internal sealed class Verifier(StorageWriter storage)
                 $"diary {diaryId}: expected {expectedEntries.Count} entries, storage returned {actualEntries.Count}");
         }
 
+        // Checking only that every source row arrived leaves the other direction blind:
+        // a row in storage with no counterpart in the source is either a leftover from a
+        // previous migration or something else writing to the same tables, and either way
+        // the operator needs to know before treating this as a faithful copy.
+        var expectedIds = expectedEntries
+            .Where(e => e.DiaryEntryId.HasValue)
+            .Select(e => e.DiaryEntryId!.Value)
+            .ToHashSet();
+
+        foreach (var extra in actualEntries.Where(e => e.DiaryEntryId.HasValue && !expectedIds.Contains(e.DiaryEntryId!.Value)))
+        {
+            _problems.Add($"entry {extra.DiaryEntryId} is in storage but not in the source");
+        }
+
         foreach (var expected in expectedEntries)
         {
             var id = expected.DiaryEntryId!.Value;
@@ -117,6 +131,15 @@ internal sealed class Verifier(StorageWriter storage)
             }
         }
 
+        // A user in storage that the source does not have is the more alarming direction:
+        // it means somebody holds an account, and a role, that the migration did not put
+        // there.
+        var expectedOids = expectedUsers.Select(u => u.EntraObjectId).ToHashSet(StringComparer.Ordinal);
+        foreach (var extra in actualUsers.Where(u => !expectedOids.Contains(u.EntraObjectId)))
+        {
+            _problems.Add($"user {extra.EntraObjectId} ({extra.Role}) is in storage but not in the source");
+        }
+
         var actualRequests = await storage.ReadAccessRequestsAsync();
         var byId = actualRequests.ToDictionary(r => r.AccessRequestId);
 
@@ -134,6 +157,12 @@ internal sealed class Verifier(StorageWriter storage)
             }
 
             CompareField(expected.AccessRequestId, "inviteRedeemUrl", expected.InviteRedeemUrl, actual.InviteRedeemUrl);
+        }
+
+        var expectedRequestIds = expectedRequests.Select(r => r.AccessRequestId).ToHashSet();
+        foreach (var extra in actualRequests.Where(r => !expectedRequestIds.Contains(r.AccessRequestId)))
+        {
+            _problems.Add($"access request {extra.AccessRequestId} ({extra.Email}) is in storage but not in the source");
         }
     }
 

--- a/src/api/ccDiaryApiTest/Storage/MigrateToolTest.cs
+++ b/src/api/ccDiaryApiTest/Storage/MigrateToolTest.cs
@@ -112,6 +112,105 @@ namespace ccDiaryApiTest.Storage
         }
 
         [TestMethod]
+        public async Task Verifier_DetectsAnEntryInStorageThatTheSourceDoesNotHave()
+        {
+            var (diary, entries) = await MigrateSampleAsync();
+
+            // Something wrote an entry the migration never put there.
+            await _storage.WriteEntryAsync(new DiaryEntryDTO
+            {
+                DiaryEntryId = Guid.NewGuid(),
+                DiaryId = diary.DiaryId!.Value,
+                Date = new DateTime(1919, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                Location = "Unexpected",
+                Entry = "Not from the source",
+            });
+
+            var verifier = new Verifier(_storage);
+
+            Assert.IsFalse(await verifier.VerifyDiaryAsync(diary, entries));
+            Assert.IsTrue(verifier.Problems.Any(p => p.Contains("in storage but not in the source", StringComparison.Ordinal)));
+        }
+
+        [TestMethod]
+        public async Task Verifier_DetectsACompensatingPair_WhereCountsStillMatch()
+        {
+            // The case a count comparison cannot see: one row missing and one extra, so
+            // the totals agree while the contents do not. This is the whole reason the
+            // check is by identity rather than by number.
+            var (diary, entries) = await MigrateSampleAsync();
+
+            await _storage.WriteEntryAsync(new DiaryEntryDTO
+            {
+                DiaryEntryId = Guid.NewGuid(),
+                DiaryId = diary.DiaryId!.Value,
+                Date = new DateTime(1919, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                Location = "Unexpected",
+                Entry = "Not from the source",
+            });
+
+            // Source expects one the migration never wrote, balancing the count exactly.
+            entries.Add(new DiaryEntryDTO
+            {
+                DiaryEntryId = Guid.NewGuid(),
+                DiaryId = diary.DiaryId!.Value,
+                Date = new DateTime(1920, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                Location = "Never written",
+                Entry = "Never written",
+            });
+
+            var actual = await _storage.Entries.GetDiaryEntriesAsync(diary.DiaryId!.Value);
+            Assert.AreEqual(entries.Count, actual.Count, "the counts must match, or this is not testing what it claims");
+
+            var verifier = new Verifier(_storage);
+
+            Assert.IsFalse(await verifier.VerifyDiaryAsync(diary, entries));
+            Assert.IsTrue(verifier.Problems.Any(p => p.Contains("missing from storage", StringComparison.Ordinal)));
+            Assert.IsTrue(verifier.Problems.Any(p => p.Contains("in storage but not in the source", StringComparison.Ordinal)));
+        }
+
+        [TestMethod]
+        public async Task Verifier_DetectsAUserInStorageThatTheSourceDoesNotHave()
+        {
+            // The alarming direction: an account, with a role, that the migration did not
+            // create.
+            await _storage.WriteUserAsync(new AppUserDto
+            {
+                UserId = Guid.NewGuid(),
+                EntraObjectId = "unexpected-admin",
+                DisplayName = "Unexpected",
+                Email = "unexpected@test.com",
+                Role = AppRole.DiaryAdmin,
+                CreatedAt = DateTime.UtcNow,
+            });
+
+            var verifier = new Verifier(_storage);
+            await verifier.VerifyUsersAndRequestsAsync([],[]);
+
+            Assert.IsTrue(verifier.Problems.Any(p =>
+                p.Contains("unexpected-admin", StringComparison.Ordinal)
+                && p.Contains("in storage but not in the source", StringComparison.Ordinal)));
+        }
+
+        [TestMethod]
+        public async Task Verifier_DetectsAnAccessRequestInStorageThatTheSourceDoesNotHave()
+        {
+            await _storage.WriteAccessRequestAsync(new AccessRequestDto
+            {
+                AccessRequestId = Guid.NewGuid(),
+                DisplayName = "Unexpected",
+                Email = "unexpected@test.com",
+                Status = RequestStatus.Pending,
+                RequestedAt = DateTime.UtcNow,
+            });
+
+            var verifier = new Verifier(_storage);
+            await verifier.VerifyUsersAndRequestsAsync([],[]);
+
+            Assert.IsTrue(verifier.Problems.Any(p => p.Contains("in storage but not in the source", StringComparison.Ordinal)));
+        }
+
+        [TestMethod]
         public async Task Verifier_DetectsADowngradedAdministratorRole()
         {
             // Losing a role silently turns an administrator into a reader, which nobody


### PR DESCRIPTION
## The gap

`--verify` proved every source row arrived and stopped there. It never asked the opposite question, so a row in storage with no counterpart in the source passed silently.

Not hypothetical. Running it against **dev** reported `VERIFIED` while storage held a dozen access requests the database did not — left by repeated e2e runs. Anyone reading that output would reasonably have concluded the two were identical. That is the failure mode this tool exists to prevent, sitting inside the tool itself.

## What was missing where

| | Before | After |
|---|---|---|
| Entries | count comparison only | compared by identity, both directions |
| Users | **no check at all** | compared by identity, both directions |
| Access requests | **no check at all** | compared by identity, both directions |

A count comparison catches the simple case but not a **compensating pair** — one row missing and one extra leaves the totals equal while the contents differ.

Extras now report the offending id, plus role or email, so an operator can judge whether it is a leftover, another writer, or a real problem.

## Tests

Four added. The important one is the compensating pair: it asserts the counts match *before* verifying, so it fails loudly if it ever stops testing what it claims to.

```
Passed! - Failed: 0, Passed: 359, Skipped: 0, Total: 359
```

## Confirmed on real data

The same dev run that previously reported `VERIFIED` now lists each unexpected row:

```
- access request 1c2dcc6b... (api-e2e-1786667116244@example-e2e.invalid) is in storage but not in the source
- access request 365780c8... (api-e2e-1786667137480@example-e2e.invalid) is in storage but not in the source
  ... and more
```

## Why now

This is the acceptance gate for the prod migration, which has not happened yet. Better to close the gap before it is used on data that matters than to discover it afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbFW1ijTd7jn6GM7jtnhdh