### PR TITLE
chore: remove the PR preview environment when a pull request closes

### DIFF
--- a/.github/workflows/cleanup-pr-preview.yml
+++ b/.github/workflows/cleanup-pr-preview.yml
@@ -1,0 +1,42 @@
+# Removes the Static Web App preview environment when a pull request closes.
+#
+# Every PR build creates one, and the Free tier allows only three at a time. Without
+# this they accumulate until an unrelated PR fails with:
+#
+#   Reason: This Static Web App already has the maximum number of staging environments.
+#
+# which surfaces as a UI deployment failing on a pull request that may not touch the UI
+# at all — an unhelpful place to begin debugging.
+#
+# This lives in its own workflow rather than as a job in build-and-test.yml: adding
+# "closed" to that workflow's pull_request trigger would run the entire build, test and
+# deploy pipeline every time a PR is closed.
+
+name: Clean up PR preview environment
+
+on:
+  pull_request:
+    types: [closed]
+
+# If a PR is closed and reopened quickly, only the latest state matters.
+concurrency:
+  group: cleanup-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  close-preview:
+    runs-on: ubuntu-latest
+
+    # The deploy token is scoped to the dev environment, and dev is where pull request
+    # previews are created.
+    environment: dev
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Close preview environment
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          action: "close"


### PR DESCRIPTION
## The problem

Every PR build creates a Static Web App preview environment, and nothing removed them. The Free tier allows **three**. PR #121 hit the ceiling:

```
Reason: This Static Web App already has the maximum number of staging environments.
```

The slots were held by previews for **#119** and **#120** — both already merged, so pure dead weight.

Two things make this worse than a simple quota error:

- It surfaces as **`deploy-ui` failing on a PR that may not touch the UI**. #121 changes one C# file and a test; a UI deployment failure is an unhelpful place to start looking.
- It gets more likely over time, not less, and the next person to hit it has no reason to connect it to PRs merged days earlier.

## The fix

A `pull_request: types: [closed]` workflow calling the same action and token the deploy uses, with `action: "close"`.

It is a **separate workflow file** on purpose: adding `closed` to `build-and-test.yml`'s trigger would run the entire build, test and deploy pipeline every time a PR is closed.

`environment: dev` because the deploy token is scoped there, and dev is where previews are created.

## Scope

Fixes it going forward only. I deleted the stale environments for #119, #120 and a #79 left over from April by hand, which unblocked #121.

A companion worth considering separately: a fail-fast guard that counts environments before building, so hitting the cap with three genuinely open PRs reports in seconds rather than minutes into the SWA action. The sibling `slypn` repository does this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbFW1ijTd7jn6GM7jtnhdh