### PR TITLE
fix: cancel the pending search timer when the scope is disposed

### DIFF
--- a/src/ui/src/composables/__tests__/useSearchDebounce.spec.ts
+++ b/src/ui/src/composables/__tests__/useSearchDebounce.spec.ts
@@ -1,6 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { effectScope, ref } from 'vue'
 import { useSearchDebounce } from '../useSearchDebounce'
+
+// The composable registers an onScopeDispose handler, so it has to run inside an effect
+// scope — which is what happens in a component anyway. Running it bare would both warn
+// and leave the disposal path untestable.
+function inScope (register: () => void) {
+  const scope = effectScope()
+  scope.run(register)
+  return scope
+}
 
 describe('useSearchDebounce', () => {
   beforeEach(() => {
@@ -14,26 +23,26 @@ describe('useSearchDebounce', () => {
   it('does not call onSearch immediately when query changes', () => {
     const query = ref('')
     const onSearch = vi.fn()
-    useSearchDebounce(query, onSearch)
+    inScope(() => useSearchDebounce(query, onSearch))
 
     query.value = 'hello'
     expect(onSearch).not.toHaveBeenCalled()
   })
 
-  it('calls onSearch after the default 300ms delay', async () => {
+  it('calls onSearch after the default 300ms delay', () => {
     const query = ref('')
     const onSearch = vi.fn()
-    useSearchDebounce(query, onSearch)
+    inScope(() => useSearchDebounce(query, onSearch))
 
     query.value = 'hello'
     vi.advanceTimersByTime(300)
     expect(onSearch).toHaveBeenCalledTimes(1)
   })
 
-  it('resets the timer when query changes again before delay elapses', async () => {
+  it('resets the timer when query changes again before delay elapses', () => {
     const query = ref('')
     const onSearch = vi.fn()
-    useSearchDebounce(query, onSearch)
+    inScope(() => useSearchDebounce(query, onSearch))
 
     query.value = 'hel'
     vi.advanceTimersByTime(200)
@@ -45,10 +54,10 @@ describe('useSearchDebounce', () => {
     expect(onSearch).toHaveBeenCalledTimes(1)
   })
 
-  it('calls onSearch only once for rapid successive changes', async () => {
+  it('calls onSearch only once for rapid successive changes', () => {
     const query = ref('')
     const onSearch = vi.fn()
-    useSearchDebounce(query, onSearch)
+    inScope(() => useSearchDebounce(query, onSearch))
 
     query.value = 'a'
     query.value = 'ab'
@@ -57,10 +66,10 @@ describe('useSearchDebounce', () => {
     expect(onSearch).toHaveBeenCalledTimes(1)
   })
 
-  it('respects a custom delay', async () => {
+  it('respects a custom delay', () => {
     const query = ref('')
     const onSearch = vi.fn()
-    useSearchDebounce(query, onSearch, 500)
+    inScope(() => useSearchDebounce(query, onSearch, 500))
 
     query.value = 'test'
     vi.advanceTimersByTime(300)
@@ -70,10 +79,10 @@ describe('useSearchDebounce', () => {
     expect(onSearch).toHaveBeenCalledTimes(1)
   })
 
-  it('calls onSearch again for each distinct settled change', async () => {
+  it('calls onSearch again for each distinct settled change', () => {
     const query = ref('')
     const onSearch = vi.fn()
-    useSearchDebounce(query, onSearch)
+    inScope(() => useSearchDebounce(query, onSearch))
 
     query.value = 'first'
     vi.advanceTimersByTime(300)
@@ -82,5 +91,31 @@ describe('useSearchDebounce', () => {
     query.value = 'second'
     vi.advanceTimersByTime(300)
     expect(onSearch).toHaveBeenCalledTimes(2)
+  })
+
+  it('cancels a pending search when the scope is disposed', () => {
+    // Navigating away mid-typing. The watcher stops itself, but before this fix the
+    // timer already in flight still fired, running the search against a page that no
+    // longer exists and raising the shared status banner on the new one.
+    const query = ref('')
+    const onSearch = vi.fn()
+    const scope = inScope(() => useSearchDebounce(query, onSearch))
+
+    query.value = 'partial'
+    vi.advanceTimersByTime(100)
+    scope.stop()
+    vi.advanceTimersByTime(1000)
+
+    expect(onSearch).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when disposed with no search pending', () => {
+    const query = ref('')
+    const onSearch = vi.fn()
+    const scope = inScope(() => useSearchDebounce(query, onSearch))
+
+    scope.stop()
+
+    expect(onSearch).not.toHaveBeenCalled()
   })
 })

--- a/src/ui/src/composables/useSearchDebounce.ts
+++ b/src/ui/src/composables/useSearchDebounce.ts
@@ -1,9 +1,19 @@
-import { type Ref, watch } from 'vue'
+import { onScopeDispose, type Ref, watch } from 'vue'
 
 export function useSearchDebounce (query: Ref<string>, onSearch: () => void, delay = 300) {
   let timer: ReturnType<typeof setTimeout> | null = null
+
   watch(query, () => {
     if (timer) clearTimeout(timer)
     timer = setTimeout(onSearch, delay)
   }, { flush: 'sync' })
+
+  // The watcher stops itself when the scope is disposed, but a timer already in flight
+  // does not. Without this, typing in the search box and navigating away within the
+  // delay still fires onSearch against a torn-down page — which writes to its refs and,
+  // via the search request, to the shared apiStatus store, so a failure there raises the
+  // global status banner on whatever page the user actually landed on.
+  onScopeDispose(() => {
+    if (timer) clearTimeout(timer)
+  })
 }


### PR DESCRIPTION
## The bug

`useSearchDebounce` stops its watcher on unmount, but a `setTimeout` already in flight keeps running.

Type in the diary search box and navigate away within the 300 ms delay, and the callback still fires against a torn-down page. It writes to that page's refs, and the search request writes to the shared `apiStatus` store — so a failure there raises the **global status banner on whatever page the user actually landed on**, with no obvious cause.

`onScopeDispose` now clears it.

## The test earns its place

The new test was run against the **unfixed** composable and fails there:

```
× useSearchDebounce > cancels a pending search when the scope is disposed
Tests  1 failed | 7 passed (8)
```

So it tests the behaviour rather than describing it.

## Spec change

The spec now runs the composable inside an `effectScope`. That is both closer to real usage — in a component there is always a scope — and what makes the disposal path testable at all: called bare, `onScopeDispose` warns and there is nothing to stop.

## Where this came from

Found by review of **PR #115**, but the code is already on `main`: the same work was merged earlier as **#114**, so #115 contains no unique UI content and this had to be fixed here instead.

444 UI tests pass, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbFW1ijTd7jn6GM7jtnhdh