### PR TITLE
docs: document the infrastructure scripts and finish the storage migration in the docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,7 +28,7 @@ ccDiary is a full-stack diary application that allows users to create, manage, a
 
 - IaC: Bicep (targeting Azure subscription scope)
 - Containerization: Docker for API
-- Cloud Platform: Microsoft Azure (Container Apps, SQL Database serverless, Static Web Apps, Entra ID)
+- Cloud Platform: Microsoft Azure (Container Apps, Table + Blob Storage, Static Web Apps, Entra ID)
 - Code Quality: SonarCloud (3 separate projects: API, UI, Infra — quality gate blocks CI on failure)
 
 ## Repository Structure
@@ -43,7 +43,7 @@ ccDiary/
     │   ├── ccDiaryApi/                # Main API project
     │   │   ├── Controllers/v1/        # API v1 controllers
     │   │   ├── Data/
-    │   │   │   ├── Context/           # Database interactions
+    │   │   │   ├── Storage/           # TableStore, BlobStore, StorageKeys, TableJson
     │   │   │   └── Model/             # Data models
     │   │   │
     │   │   ├── Services/              # Service layer
@@ -116,12 +116,25 @@ ccDiary/
 ### Scripts (scripts)
 | Script | Description |
 |---|---|
-| buildAllInfrastructure.ps1 | Deploy infrastructure for all environments (dev, staging, prod) sequentially |
-| buildInfrastructure.ps1 | Build infrastructure in Azure |
-| startLocal.ps1 | Run UI and API if not running |
+| buildAllInfrastructure.ps1 | Deploy dev → staging → prod sequentially; **stops at the first failure** |
+| buildInfrastructure.ps1 | Provision one environment end to end (bicep, Entra, RBAC, GitHub secrets/variables) |
+| entraSetup.ps1 | Create or update the Entra app registration; called by the two setup scripts |
+| startLocal.ps1 | Ensure Azurite, then run API and UI if not already running |
 | stopLocal.ps1 | Kill UI and API processes (preserves VS Code and Visual Studio) |
-| run-coverage-summary.ps1 | Run coverage for API and UI |
+| run-coverage-summary.ps1 | Ensure Azurite, then run coverage for API and UI |
 | setuplocal.ps1 | Setup local environment |
+
+#### Re-running buildInfrastructure.ps1 against a live environment
+
+The bicep template is authoritative for the container spec, but most application configuration is applied *after* deployment because it depends on outputs that deployment produces. Anything the template does not declare is therefore erased. `existingEnvVars`, `existingSecretRefs` and `existingSecrets` exist solely to feed the running state back in, and the deployed image tag is read back and re-passed — without them a redeploy takes the environment down and rolls it to `:latest`. The deployment runs twice, because the Entra client secret cannot exist until the first run produces the URLs the app registration is built from.
+
+Sensitive values are container app secrets referenced with `secretref:`, never inline environment variables. `az ad app credential reset` returns no `keyId`, so credentials to retire are captured before the new one is issued. An app registration caps at two secrets; `entraSetup.ps1` mints one only with `-CreateClientSecret` and evicts only its own.
+
+#### Windows shell hazard
+
+`az` is a batch file, so cmd.exe re-parses the command line after PowerShell strips the quotes. Values containing `|`, `&` or `()` break and are not reliably escapable — passing plainly is rejected, and embedded quotes can return exit 0 while doing nothing. Secrets travel in the deployment parameter file (BOM-less UTF-8), and `--query` expressions avoid parentheses.
+
+**Azurite must be running for anything that touches storage** — it is the whole persistence tier, so the API fails to start without it and the symptom is a port timeout. Compose owns the single definition: `docker compose -p ccdiary -f src/api/docker-compose.yml up -d azurite`.
 
 ## Testing
 
@@ -216,4 +229,4 @@ SonarCloud organization (`cookingcode`)
 
 ---
 
-**Last Updated**: 2026-04-06
+**Last Updated**: 2026-08-18

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ ccDiary is a full-stack diary application — ASP.NET Core 8 API + Vue 3/Vuetify
 
 - IaC: Bicep (targeting Azure subscription scope)
 - Containerization: Docker for API, image pushed to GHCR
-- Cloud Platform: Microsoft Azure (Container Apps, SQL Database serverless, Static Web Apps, Entra ID)
+- Cloud Platform: Microsoft Azure (Container Apps, Table + Blob Storage, Static Web Apps, Entra ID)
 - Code Quality: SonarCloud (3 separate projects: API, UI, Infra — quality gate blocks CI on failure)
 
 ## Repository Structure
@@ -209,12 +209,37 @@ npx playwright test --grep "cookie preferences"
 
 | Script | Description |
 |---|---|
-| buildAllInfrastructure.ps1 | Deploy infrastructure for all environments (dev, staging, prod) sequentially |
-| buildInfrastructure.ps1 | Build infrastructure in Azure |
-| startLocal.ps1 | Run UI and API if not running |
+| buildAllInfrastructure.ps1 | Deploy dev → staging → prod sequentially; **stops at the first failure** |
+| buildInfrastructure.ps1 | Provision one environment end to end (bicep, Entra, RBAC, GitHub secrets/variables) |
+| entraSetup.ps1 | Create or update the Entra app registration; called by the two setup scripts |
+| startLocal.ps1 | Ensure Azurite, then run API and UI if not already running |
 | stopLocal.ps1 | Kill UI and API processes (preserves VS Code and Visual Studio) |
-| run-coverage-summary.ps1 | Run coverage for API and UI |
+| run-coverage-summary.ps1 | Ensure Azurite, then run coverage for API and UI |
 | setuplocal.ps1 | Setup local environment |
+
+Ordering in `buildAllInfrastructure.ps1` is deliberate: each environment rehearses the next, so a dev failure is evidence prod should not be attempted. Remaining environments are reported as `Skipped`, not omitted.
+
+#### Re-running `buildInfrastructure.ps1` against a live environment
+
+This is the part that is not visible from any single file. The bicep template is **authoritative for the container spec**, but most application configuration is applied *after* deployment, because it depends on outputs that deployment produces (the container and static site FQDNs feed the Entra app registration, which yields the client id and secret). Anything the template does not declare is therefore erased on redeployment.
+
+Three parameters exist solely to feed the running state back in — `existingEnvVars`, `existingSecretRefs`, `existingSecrets` — captured from the deployed app immediately before deploying. Removing that plumbing takes the environment down rather than merely losing configuration: the app fails fast without `Storage__AccountName`, and ingress sends 100% of traffic to the latest revision. A template that omits `secrets` deletes them, leaving every `secretRef` pointing at nothing.
+
+The deployed **image tag** is read back and re-passed for the same reason. `DevApiContainerImage` is an untagged dev reference, and unlike the environment variables the script never sets the image again afterwards, so passing it would permanently and silently roll a promoted environment to `:latest`.
+
+The deployment runs **twice**: the Entra client secret cannot exist until the first run has produced the URLs the app registration is built from.
+
+#### Credentials
+
+- Sensitive values are **container app secrets** referenced with `secretref:`, never inline environment variables. An inline value is part of the container spec, so `az containerapp show`, what-if diffs and any CLI error that echoes its arguments print it in full.
+- `az ad app credential reset` returns `appId`/`password`/`tenant` and **no `keyId`**, so the credentials to retire are captured *before* the new one is issued. Identifying the survivor from the reset output yields null and deletes everything.
+- An app registration caps at two secrets. `entraSetup.ps1` mints one only when passed `-CreateClientSecret` (`setuplocal.ps1` does, `buildInfrastructure.ps1` does not, since it issues its own), and evicts only secrets it created.
+
+#### Windows shell hazard
+
+`az` is a batch file, so **cmd.exe re-parses the command line after PowerShell has stripped the quotes**. Values containing `|`, `&` or `()` break: a password is split into fragments, and JMESPath `length()` dies with `--output was unexpected at this time`. This is not reliably escapable — passing a value plainly is rejected, and passing it with embedded quotes can return exit 0 while doing nothing at all.
+
+Consequently: secrets travel in the deployment **parameter file** (BOM-less UTF-8 via `WriteAllText`; `Set-Content` emits a BOM that az refuses), and `--query` expressions avoid parentheses — project the field and count in PowerShell instead.
 
 ## Testing
 
@@ -306,6 +331,10 @@ Sensitive values are never committed — use **user secrets** (`dotnet user-secr
 
 Environment names are matched case-insensitively in `Program.cs` for `Local`, `LocalContainer`, and `LocalCompose` — user secrets load for all of them.
 
+In the deployed environments `Graph__ClientSecret`, `Smtp__Password` and `OTEL_EXPORTER_OTLP_HEADERS` are **container app secrets**, so the container spec shows `secretRef` names rather than values. Set them through the deployment, not `az containerapp update --set-env-vars`.
+
+**Azurite must be running for anything that touches storage** — it is the whole persistence tier, so the API's `StorageBootstrapper` throws and the host never starts without it. The symptom is a port timeout, not a storage error. `startLocal.ps1` and `run-coverage-summary.ps1` start it; otherwise `docker compose -p ccdiary -f src/api/docker-compose.yml up -d azurite`. Compose owns the single definition — do not `docker run` a second container, since it claims the same name.
+
 ### OpenTelemetry (API)
 
 Configured in `OpenTelemetryExtensions.cs`. When `OTEL_EXPORTER_OTLP_ENDPOINT` is set:
@@ -365,4 +394,4 @@ Pick the project key matching the directory you are working in. After fixing iss
 
 ---
 
-**Last Updated**: 2026-08-12
+**Last Updated**: 2026-08-18

--- a/architecture.md
+++ b/architecture.md
@@ -21,17 +21,27 @@ architecture-beta
             service ca(azure:container-apps)["ca-ccdiary-{env}\nASP.NET Core 8 · port 8080\n0.25 vCPU · 0.5 GiB · 0–1 replicas"]
         end
         service logs(azure:log-analytics-workspaces)["logs-ccdiary-{env}\n30-day retention\nAzure Monitor"]
-        service db(azure:sql-database)["sql-ccdiary-{env}.database.windows.net\nDB: sqldb-ccdiary-{env}\nGP_S_Gen5_1 serverless · Managed Identity"]
+        service store(azure:storage-accounts)["st{name}{env}{hash}\nStandard_LRS · Hot\n6 tables · 3 blob containers"]
     end
 
     user:R --> L:swa
     entra:B --> T:swa
     swa:B --> T:ca
     ghcr:R --> L:ca
-    ca:B --> T:db
+    ca:B --> T:store
     ca:R --> L:logs
     grafana:B --> T:logs
 ```
+
+The Container App reaches storage with its **system-assigned managed identity**, holding no connection string: `allowSharedKeyAccess` is `false`, and the resource group template grants the identity *Storage Table Data Contributor* and *Storage Blob Data Contributor* on the account. Those are data-plane roles — the control-plane *Storage Account Contributor* grants no access to the tables or blobs themselves.
+
+| Container | Contents | Retention |
+|---|---|---|
+| `images` | `{diaryId}/{diaryEntryId}` — entry images | blob soft delete, 7 days |
+| `mapcache` | `tiles/{source}/{z}/{x}/{y}`, `routes/{profile}/{key}.json` | lifecycle policy deletes after 90 days |
+| `content` | `entries/{diaryEntryId}.json` — spill for oversized entry JSON | blob soft delete, 7 days |
+
+Tables: `diary`, `diaryentry`, `appuser`, `accessrequest`, `appinfo`, `geocodingcache`. They are declared in bicep *and* created at boot by `StorageBootstrapper`, so local development against Azurite works without a deployment.
 
 ---
 
@@ -59,9 +69,9 @@ flowchart TB
         direction LR
         DevSWA["stapp-ccdiary-dev\n.azurestaticapps.net"]
         DevCA["ca-ccdiary-dev\n(cae-ccdiary-dev)"]
-        DevDB[("sql-ccdiary-dev\nsqldb-ccdiary-dev")]
+        DevStore[("st-ccdiary-dev\nTable + Blob")]
         DevLog["logs-ccdiary-dev"]
-        DevSWA --> DevCA --> DevDB
+        DevSWA --> DevCA -->|managed identity| DevStore
         DevCA --> DevLog
     end
 
@@ -69,9 +79,9 @@ flowchart TB
         direction LR
         StgSWA["stapp-ccdiary-staging\n.azurestaticapps.net"]
         StgCA["ca-ccdiary-staging\n(cae-ccdiary-staging)"]
-        StgDB[("sql-ccdiary-staging\nsqldb-ccdiary-staging")]
+        StgStore[("st-ccdiary-staging\nTable + Blob")]
         StgLog["logs-ccdiary-staging"]
-        StgSWA --> StgCA --> StgDB
+        StgSWA --> StgCA -->|managed identity| StgStore
         StgCA --> StgLog
     end
 
@@ -79,9 +89,9 @@ flowchart TB
         direction LR
         ProdSWA["stapp-ccdiary-prod\n+ custom domain"]
         ProdCA["ca-ccdiary-prod\n(cae-ccdiary-prod)"]
-        ProdDB[("sql-ccdiary-prod\nsqldb-ccdiary-prod")]
+        ProdStore[("st-ccdiary-prod\nTable + Blob")]
         ProdLog["logs-ccdiary-prod"]
-        ProdSWA --> ProdCA --> ProdDB
+        ProdSWA --> ProdCA -->|managed identity| ProdStore
         ProdCA --> ProdLog
     end
 
@@ -109,13 +119,12 @@ Resource names follow the pattern `{prefix}-ccdiary-{env}`. Container App FQDNs 
 | **Container App** | `ca-ccdiary-dev.{suffix}.azurecontainerapps.io` | `ca-ccdiary-staging.{suffix}.azurecontainerapps.io` | `ca-ccdiary-prod.{suffix}.azurecontainerapps.io` |
 | **Container App Env** | `cae-ccdiary-dev` | `cae-ccdiary-staging` | `cae-ccdiary-prod` |
 | **Storage account** | `stccdiarydevcog5wcxyf3cz` | `stccdiarystagingn5tdd4wc` | `stccdiaryprod6vcphn6hsut` |
-| **SQL Database** | `sqldb-ccdiary-dev` | `sqldb-ccdiary-staging` | `sqldb-ccdiary-prod` |
 | **Log Analytics** | `logs-ccdiary-dev` | `logs-ccdiary-staging` | `logs-ccdiary-prod` |
 | **Container Image** | `ghcr.io/sinclapa/ccdiary-api:{semver}` | `ghcr.io/sinclapa/ccdiary-api:{semver}` | `ghcr.io/sinclapa/ccdiary-api:{semver}` |
 | **GitHub Environment** | `dev` | `staging` | `prod` |
 | **Deploy Trigger** | Push to any non-main branch | Push / merge to `main` | GitHub Release tag `v*` |
-| **SQL Auth** | Managed Identity (Entra-only) | Managed Identity (Entra-only) | Managed Identity (Entra-only) |
-| **SQL SKU** | GP_S_Gen5_1 serverless | GP_S_Gen5_1 serverless | GP_S_Gen5_1 serverless |
+| **Storage Auth** | Managed identity + RBAC (`allowSharedKeyAccess: false`) | Managed identity + RBAC | Managed identity + RBAC |
+| **Storage SKU** | Standard_LRS · Hot | Standard_LRS · Hot | Standard_LRS · Hot |
 | **CA Resources** | 0.25 vCPU · 0.5 GiB | 0.25 vCPU · 0.5 GiB | 0.25 vCPU · 0.5 GiB |
 | **CA Scale** | 0–1 replicas | 0–1 replicas | 0–1 replicas |
 | **OTLP Endpoint** | `otlp-gateway-prod-gb-south-1.grafana.net/otlp` | `otlp-gateway-prod-gb-south-1.grafana.net/otlp` | `otlp-gateway-prod-gb-south-1.grafana.net/otlp` |
@@ -134,13 +143,13 @@ flowchart LR
         ViteDev["⚡ Vite Dev Server\nlocalhost:8080\nnpm run dev"]
         API["🔧 ASP.NET Core API\nlocalhost:7183 HTTPS\ndotnet run"]
         subgraph Docker["🐳 Docker Compose"]
-            SQL[("🗄️ Azurite\nlocalhost:10000-10002\nazure-storage/azurite")]
+            Azurite[("🗄️ Azurite\nlocalhost:10000-10002\nazure-storage/azurite")]
         end
     end
 
     Browser -->|"http://localhost:8080"| ViteDev
     ViteDev -->|"REST /api/v1/"| API
-    API -->|"Table + Blob SDK\nbootstrap on startup"| SQL
+    API -->|"Table + Blob SDK\nbootstrap on startup"| Azurite
 ```
 
 | Component | Value |
@@ -148,7 +157,11 @@ flowchart LR
 | UI | `http://localhost:8080` |
 | API | `https://localhost:7183` |
 | Swagger | `https://localhost:7183/swagger` |
-| SQL port | `51433` (mapped from container `1433`) |
+| Azurite ports | `10000` blob · `10001` queue · `10002` table |
 | Auth config | User secrets (`Entra:ClientId`, `Entra:TenantId`) |
-| DB password | `.env` → `SA_PASSWORD` |
+| Storage config | `Storage:ConnectionString` in `appsettings.{Development,Local}.json` (Azurite well-known account) |
 | `VITE_ENVIRONMENT` | `local` (from `.env.dev.local`) |
+
+Azurite is not optional: it is the entire persistence tier, so `StorageBootstrapper` throws and the host never starts without it — the symptom is the API port never opening rather than a storage error. `scripts/startLocal.ps1` and `scripts/run-coverage-summary.ps1` start it; otherwise `docker compose -p ccdiary -f src/api/docker-compose.yml up -d azurite`. Compose owns the single definition, so do not start a second container by hand — it claims the same name.
+
+Container-hosted modes (`LocalCompose`, `LocalContainer`) reach it at the `azurite` hostname rather than `127.0.0.1`, which is why they have their own `appsettings` files.


### PR DESCRIPTION
Follow-up to #130. The script changes merged; this is the documentation for them, plus three files that still described the SQL Server the storage migration removed.

## What the instruction files were missing

`CLAUDE.md` and its Copilot mirror described the application architecture well — the DB-role-to-claim flow, kebab-case enum serialisation, runtime UI config, the frozen `StorageKeys` — but said almost nothing about `scripts/`, which is where the least obvious behaviour lives. The scripts table was six rows of one-line descriptions.

Added the parts that cannot be seen from any single file:

- **Why re-running `buildInfrastructure.ps1` against a live environment works the way it does.** The bicep template is authoritative for the container spec, but most configuration is applied *after* deployment because it depends on outputs deployment produces. `existingEnvVars` / `existingSecretRefs` / `existingSecrets` and the image-tag read-back are therefore load-bearing, not defensive: removing them takes the environment down and rolls it to `:latest`.
- **Why the deployment runs twice** — the Entra client secret cannot exist until the first run produces the URLs the app registration is built from.
- **Credential handling** — secrets are container app secrets referenced with `secretref:`, `az ad app credential reset` returns no `keyId` (so retirees are captured *before* the reset), and an app registration caps at two secrets.
- **The Windows quoting hazard.** `az` is a batch file, so cmd.exe re-parses the command line after PowerShell strips the quotes. Values containing `|`, `&` or `()` break, and it is not reliably escapable — passing plainly is rejected, and embedded quotes can return exit 0 while doing nothing. This caused several failures while writing #130 and is worth stating once.
- **Azurite is mandatory**, and its absence presents as the API port never opening rather than as a storage error.

## architecture.md

Still showed a SQL Database node in every environment diagram, `GP_S_Gen5_1 serverless`, and a local development section with a SQL port and `SA_PASSWORD`. The migration had updated some labels but not the structure — the local-dev diagram had a node named `SQL` with "Azurite" written on it.

- Resource diagram: SQL node replaced with the storage account, plus what each blob container holds and the retention that applies (`mapcache` on the 90-day lifecycle policy; `images` and `content` on 7-day soft delete).
- Environment flowchart: all three SQL nodes replaced, arrows labelled `managed identity` rather than left unlabelled.
- Instance table: `SQL Auth` / `SQL SKU` became `Storage Auth` / `Storage SKU`, recording `allowSharedKeyAccess: false`.
- Local development: Azurite ports, and where the storage connection string actually lives.

Also corrected in both instruction files: the cloud platform still listed "SQL Database serverless", and the Copilot file still showed the deleted EF `Data/Context/` folder.

## Verification

No SQL references remain in any of the three files. Mermaid fences balance 3/3 in `architecture.md`, and every renamed node has a matching arrow.

Documentation only — no code, so no tests apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbFW1ijTd7jn6GM7jtnhdh